### PR TITLE
OPAL-393 (Fix calls to get_file_system when no S3_ENDPOINT exists)

### DIFF
--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -26,7 +26,7 @@ from .index.index_sql import IndexSQL
 from .pantry import Pantry
 from .metadata_db import load_mongo
 
-__version__ = "1.6.2"
+__version__ = "1.6.3"
 
 __all__ = [
     "Basket",

--- a/weave/basket.py
+++ b/weave/basket.py
@@ -22,17 +22,20 @@ class BasketInitializer:
         basket_address: str
             Argument can take one of two forms: either a path to the basket
             directory, or the UUID of the basket.
-        **file_system: fsspec object (optional)
+        **file_system: fsspec object (optional, defaults to get_file_system())
             The fsspec filesystem to be used for retrieving and uploading. This
-            is only used when basket_address is a path.
-        **pantry: weave.Pantry (optional)
+            is only used when basket_address is a path and no Pantry object is
+            supplied.
+        **pantry: weave.Pantry (required if using UUID address)
             The pantry which the basket uuid is associated with. Only for UUID.
         """
 
         if "pantry" in kwargs:
             self.file_system = kwargs["pantry"].file_system
         else:
-            self.file_system = kwargs.get("file_system", get_file_system())
+            self.file_system = kwargs.get("file_system", None)
+            if self.file_system is None:
+                self.file_system = get_file_system()
         try:
             self._set_up_basket_from_path(basket_address)
         except ValueError as error:

--- a/weave/metadata_db.py
+++ b/weave/metadata_db.py
@@ -64,7 +64,9 @@ def load_mongo(index_table, collection="metadata", **kwargs):
             raise ValueError("Invalid index_table: missing "
                              f"{required_column} column")
 
-    file_system = kwargs.get("file_system", get_file_system())
+    file_system = kwargs.get("file_system", None)
+    if file_system is None:
+        file_system = get_file_system()
     database = get_mongo_db().mongo_metadata
 
     for _, row in index_table.iterrows():

--- a/weave/pantry.py
+++ b/weave/pantry.py
@@ -39,7 +39,9 @@ class Pantry():
             config.
         """
 
-        self.file_system = kwargs.pop("file_system", get_file_system())
+        self.file_system = kwargs.pop("file_system", None)
+        if self.file_system is None:
+            self.file_system = get_file_system()
         if isinstance(self.file_system, s3fs.S3FileSystem):
             try:
                 self.file_system.ls(pantry_path)

--- a/weave/tests/pytest_resources.py
+++ b/weave/tests/pytest_resources.py
@@ -5,8 +5,23 @@ import os
 import io
 
 import pandas as pd
+import s3fs
+from fsspec.implementations.local import LocalFileSystem
 
 from weave.upload import UploadBasket
+
+
+def get_file_systems():
+    """Returns a list of file systems and their display names."""
+    file_systems = [LocalFileSystem()]
+    file_systems_ids = ["LocalFileSystem"]
+    if "S3_ENDPOINT" in os.environ:
+        s3 = s3fs.S3FileSystem(
+            client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
+        )
+        file_systems.append(s3)
+        file_systems_ids.append("S3FileSystem")
+    return (file_systems, file_systems_ids)
 
 
 def get_sample_basket_df():

--- a/weave/tests/test_basket.py
+++ b/weave/tests/test_basket.py
@@ -18,7 +18,7 @@ from weave.basket import Basket
 from weave.index.create_index import create_index_from_fs
 from weave.pantry import Pantry
 from weave.index.index_pandas import IndexPandas
-from weave.tests.pytest_resources import PantryForTest
+from weave.tests.pytest_resources import PantryForTest, get_file_systems
 
 ###############################################################################
 #                      Pytest Fixtures Documentation:                         #
@@ -35,17 +35,11 @@ from weave.tests.pytest_resources import PantryForTest
 # point in the future the two need to be differentiated.
 # pylint: disable=duplicate-code
 
-file_systems = [LocalFileSystem()]
-file_systems_ids = ["LocalFileSystem"]
-if "S3_ENDPOINT" in os.environ:
-    s3 = s3fs.S3FileSystem(
-        client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
-    )
-    file_systems.append(s3)
-    file_systems_ids.append("S3FileSystem")
+# Create fsspec objects to be tested, and add to file_systems list.
+file_systems, file_systems_ids = get_file_systems()
 
 
-# Test with two different fsspec file systems (above).
+# Test with different fsspec file systems (above).
 @pytest.fixture(
     name="test_pantry",
     params=file_systems,

--- a/weave/tests/test_index.py
+++ b/weave/tests/test_index.py
@@ -99,10 +99,7 @@ def fixture_test_index_only(request):
     type checking tests, etc.)
     """
     index_constructor = request.param
-    try:
-        file_system = weave.config.get_file_system()
-    except Exception:
-        file_system = LocalFileSystem()
+    file_system = LocalFileSystem()
     pantry_path = (
         "pytest-temp-pantry" f"{os.environ.get('WEAVE_PYTEST_SUFFIX', '')}"
     )

--- a/weave/tests/test_index.py
+++ b/weave/tests/test_index.py
@@ -48,11 +48,14 @@ from weave.tests.pytest_resources import cleanup_sql_index
 
 
 # Create fsspec objects to be tested, and add to file_systems list.
-s3 = s3fs.S3FileSystem(
-    client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
-)
+file_systems = []
+if "S3_ENDPOINT" in os.environ:
+    s3 = s3fs.S3FileSystem(
+        client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
+    )
+    file_systems = [s3]
 local_fs = LocalFileSystem()
-file_systems = [s3, local_fs]
+file_systems.append(local_fs)
 
 # Create Index CONSTRUCTORS of Indexes to be tested, and add to indexes list.
 indexes = [IndexPandas, IndexSQLite]
@@ -104,7 +107,10 @@ def fixture_test_index_only(request):
     type checking tests, etc.)
     """
     index_constructor = request.param
-    file_system = weave.config.get_file_system()
+    try:
+        file_system = weave.config.get_file_system()
+    except Exception:
+        file_system = LocalFileSystem()
     pantry_path = (
         "pytest-temp-pantry" f"{os.environ.get('WEAVE_PYTEST_SUFFIX', '')}"
     )

--- a/weave/tests/test_index.py
+++ b/weave/tests/test_index.py
@@ -11,7 +11,6 @@ from datetime import datetime, timedelta, timezone
 import numpy as np
 import pandas as pd
 import pytest
-import s3fs
 import fsspec
 from fsspec.implementations.local import LocalFileSystem
 
@@ -22,7 +21,7 @@ from weave import Pantry
 from weave.index.index_pandas import IndexPandas
 from weave.index.create_index import create_index_from_fs
 from weave.tests.pytest_resources import PantryForTest, IndexForTest
-from weave.tests.pytest_resources import cleanup_sql_index
+from weave.tests.pytest_resources import cleanup_sql_index, get_file_systems
 
 
 ###############################################################################
@@ -48,14 +47,7 @@ from weave.tests.pytest_resources import cleanup_sql_index
 
 
 # Create fsspec objects to be tested, and add to file_systems list.
-file_systems = []
-if "S3_ENDPOINT" in os.environ:
-    s3 = s3fs.S3FileSystem(
-        client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
-    )
-    file_systems = [s3]
-local_fs = LocalFileSystem()
-file_systems.append(local_fs)
+file_systems, _ = get_file_systems()
 
 # Create Index CONSTRUCTORS of Indexes to be tested, and add to indexes list.
 indexes = [IndexPandas, IndexSQLite]

--- a/weave/tests/test_index_pandas.py
+++ b/weave/tests/test_index_pandas.py
@@ -3,12 +3,10 @@ import os
 import re
 
 import pytest
-import s3fs
-from fsspec.implementations.local import LocalFileSystem
 
 from weave.pantry import Pantry
 from weave.index.index_pandas import IndexPandas
-from weave.tests.pytest_resources import PantryForTest
+from weave.tests.pytest_resources import PantryForTest, get_file_systems
 
 
 ###############################################################################
@@ -26,17 +24,11 @@ from weave.tests.pytest_resources import PantryForTest
 # point in the future the two need to be differentiated.
 # pylint: disable=duplicate-code
 
-file_systems = [LocalFileSystem()]
-file_systems_ids = ["LocalFileSystem"]
-if "S3_ENDPOINT" in os.environ:
-    s3 = s3fs.S3FileSystem(
-        client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
-    )
-    file_systems.append(s3)
-    file_systems_ids.append("S3FileSystem")
+# Create fsspec objects to be tested, and add to file_systems list.
+file_systems, file_systems_ids = get_file_systems()
 
 
-# Test with two different fsspec file systems (above).
+# Test with different fsspec file systems (above).
 @pytest.fixture(
     name="test_pantry",
     params=file_systems,

--- a/weave/tests/test_index_pandas.py
+++ b/weave/tests/test_index_pandas.py
@@ -26,17 +26,21 @@ from weave.tests.pytest_resources import PantryForTest
 # point in the future the two need to be differentiated.
 # pylint: disable=duplicate-code
 
-s3 = s3fs.S3FileSystem(
-    client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
-)
-local_fs = LocalFileSystem()
+file_systems = [LocalFileSystem()]
+file_systems_ids = ["LocalFileSystem"]
+if "S3_ENDPOINT" in os.environ:
+    s3 = s3fs.S3FileSystem(
+        client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
+    )
+    file_systems.append(s3)
+    file_systems_ids.append("S3FileSystem")
 
 
 # Test with two different fsspec file systems (above).
 @pytest.fixture(
     name="test_pantry",
-    params=[s3, local_fs],
-    ids=["S3FileSystem", "LocalFileSystem"],
+    params=file_systems,
+    ids=file_systems_ids,
 )
 def fixture_test_pantry(request, tmpdir):
     """Sets up test pantry for the tests"""

--- a/weave/tests/test_index_sql.py
+++ b/weave/tests/test_index_sql.py
@@ -24,17 +24,21 @@ from weave.tests.pytest_resources import IndexForTest
 from weave.tests.pytest_resources import PantryForTest
 from weave.tests.pytest_resources import get_sample_basket_df
 
-s3 = s3fs.S3FileSystem(
-    client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
-)
-local_fs = LocalFileSystem()
+file_systems = [LocalFileSystem()]
+file_systems_ids = ["LocalFileSystem"]
+if "S3_ENDPOINT" in os.environ:
+    s3 = s3fs.S3FileSystem(
+        client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
+    )
+    file_systems.append(s3)
+    file_systems_ids.append("S3FileSystem")
 
 
 # Test with two different fsspec file systems (above).
 @pytest.fixture(
     name="test_pantry",
-    params=[s3, local_fs],
-    ids=["S3FileSystem", "LocalFileSystem"],
+    params=file_systems,
+    ids=file_systems_ids,
 )
 def fixture_test_pantry(request, tmpdir):
     """Sets up test pantry for the tests"""
@@ -52,7 +56,7 @@ def fixture_test_pantry(request, tmpdir):
 def fixture_test_index(request):
     """Sets up test index for the tests"""
     index_constructor = request.param
-    test_index = IndexForTest(index_constructor, local_fs)
+    test_index = IndexForTest(index_constructor, LocalFileSystem())
     yield test_index
     test_index.cleanup_index()
 

--- a/weave/tests/test_index_sql.py
+++ b/weave/tests/test_index_sql.py
@@ -16,25 +16,18 @@ except AssertionError:
 else:
     _HAS_REQUIRED_DEPS = True
 import pytest
-import s3fs
 from fsspec.implementations.local import LocalFileSystem
 
 from weave.index.index_sql import IndexSQL
-from weave.tests.pytest_resources import IndexForTest
+from weave.tests.pytest_resources import IndexForTest, get_file_systems
 from weave.tests.pytest_resources import PantryForTest
 from weave.tests.pytest_resources import get_sample_basket_df
 
-file_systems = [LocalFileSystem()]
-file_systems_ids = ["LocalFileSystem"]
-if "S3_ENDPOINT" in os.environ:
-    s3 = s3fs.S3FileSystem(
-        client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
-    )
-    file_systems.append(s3)
-    file_systems_ids.append("S3FileSystem")
+# Create fsspec objects to be tested, and add to file_systems list.
+file_systems, file_systems_ids = get_file_systems()
 
 
-# Test with two different fsspec file systems (above).
+# Test with different fsspec file systems (above).
 @pytest.fixture(
     name="test_pantry",
     params=file_systems,

--- a/weave/tests/test_index_sqlite.py
+++ b/weave/tests/test_index_sqlite.py
@@ -2,12 +2,10 @@
 import os
 
 import pytest
-import s3fs
-from fsspec.implementations.local import LocalFileSystem
 
 from weave.pantry import Pantry
 from weave.index.index_sqlite import IndexSQLite
-from weave.tests.pytest_resources import get_sample_basket_df
+from weave.tests.pytest_resources import get_sample_basket_df, get_file_systems
 from weave.tests.pytest_resources import IndexForTest
 from weave.tests.pytest_resources import PantryForTest
 
@@ -27,17 +25,11 @@ from weave.tests.pytest_resources import PantryForTest
 # point in the future the two need to be differentiated.
 # pylint: disable=duplicate-code
 
-file_systems = [LocalFileSystem()]
-file_systems_ids = ["LocalFileSystem"]
-if "S3_ENDPOINT" in os.environ:
-    s3 = s3fs.S3FileSystem(
-        client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
-    )
-    file_systems.append(s3)
-    file_systems_ids.append("S3FileSystem")
+# Create fsspec objects to be tested, and add to file_systems list.
+file_systems, file_systems_ids = get_file_systems()
 
 
-# Test with two different fsspec file systems (above).
+# Test with different fsspec file systems (above).
 @pytest.fixture(
     name="test_pantry",
     params=file_systems,

--- a/weave/tests/test_metadata_db.py
+++ b/weave/tests/test_metadata_db.py
@@ -47,16 +47,20 @@ class MongoForTest(PantryForTest):
         self.mongodb[self.test_collection].drop()
 
 
-s3 = s3fs.S3FileSystem(
-    client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
-)
-local_fs = LocalFileSystem()
+file_systems = [LocalFileSystem()]
+file_systems_ids = ["LocalFileSystem"]
+if "S3_ENDPOINT" in os.environ:
+    s3 = s3fs.S3FileSystem(
+        client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
+    )
+    file_systems.append(s3)
+    file_systems_ids.append("S3FileSystem")
 
 
 # Test with two different fsspec file systems (above).
 @pytest.fixture(
-    params=[s3, local_fs],
-    ids=["S3FileSystem", "LocalFileSystem"],
+    params=file_systems,
+    ids=file_systems_ids,
 )
 def set_up(request, tmpdir):
     """Sets up the fixture for testing usage."""

--- a/weave/tests/test_metadata_db.py
+++ b/weave/tests/test_metadata_db.py
@@ -5,11 +5,9 @@ import sys
 
 import pandas as pd
 import pytest
-import s3fs
-from fsspec.implementations.local import LocalFileSystem
 
 import weave
-from weave.tests.pytest_resources import PantryForTest
+from weave.tests.pytest_resources import PantryForTest, get_file_systems
 
 
 class MongoForTest(PantryForTest):
@@ -47,17 +45,11 @@ class MongoForTest(PantryForTest):
         self.mongodb[self.test_collection].drop()
 
 
-file_systems = [LocalFileSystem()]
-file_systems_ids = ["LocalFileSystem"]
-if "S3_ENDPOINT" in os.environ:
-    s3 = s3fs.S3FileSystem(
-        client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
-    )
-    file_systems.append(s3)
-    file_systems_ids.append("S3FileSystem")
+# Create fsspec objects to be tested, and add to file_systems list.
+file_systems, file_systems_ids = get_file_systems()
 
 
-# Test with two different fsspec file systems (above).
+# Test with different fsspec file systems (above).
 @pytest.fixture(
     params=file_systems,
     ids=file_systems_ids,

--- a/weave/tests/test_pantry.py
+++ b/weave/tests/test_pantry.py
@@ -17,7 +17,7 @@ from weave import Basket
 from weave.index.create_index import create_index_from_fs
 from weave.index.index_pandas import IndexPandas
 from weave.pantry import Pantry
-from weave.tests.pytest_resources import PantryForTest
+from weave.tests.pytest_resources import PantryForTest, get_file_systems
 from weave.__init__ import __version__ as weave_version
 
 
@@ -42,17 +42,11 @@ from weave.__init__ import __version__ as weave_version
 # point in the future there is a need to differentiate the two.
 # pylint: disable=duplicate-code
 
-file_systems = [LocalFileSystem()]
-file_systems_ids = ["LocalFileSystem"]
-if "S3_ENDPOINT" in os.environ:
-    s3 = s3fs.S3FileSystem(
-        client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
-    )
-    file_systems.append(s3)
-    file_systems_ids.append("S3FileSystem")
+# Create fsspec objects to be tested, and add to file_systems list.
+file_systems, file_systems_ids = get_file_systems()
 
 
-# Test with two different fsspec file systems (above).
+# Test with different fsspec file systems (above).
 @pytest.fixture(
     name="test_pantry",
     params=file_systems,

--- a/weave/tests/test_pytest.py
+++ b/weave/tests/test_pytest.py
@@ -1,10 +1,8 @@
 """This script contains tests that test that pytest is deleting baskets
 correctly."""
-
 import os
 import sys
 
-from fsspec.implementations.local import LocalFileSystem
 # Try-Except required to make psycopg2 an optional dependency.
 # Ignore pylint. This is used to explicitly show the optional dependency.
 # pylint: disable=duplicate-code
@@ -15,23 +13,15 @@ except ImportError:
 else:
     _HAS_PSYCOPG = True
 import pytest
-import s3fs
 
-from weave.tests.pytest_resources import PantryForTest
-
-
-file_systems = [LocalFileSystem()]
-file_systems_ids = ["LocalFileSystem"]
-if "S3_ENDPOINT" in os.environ:
-    s3 = s3fs.S3FileSystem(
-        client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
-    )
-    file_systems.append(s3)
-    file_systems_ids.append("S3FileSystem")
+from weave.tests.pytest_resources import PantryForTest, get_file_systems
 
 
+# Create fsspec objects to be tested, and add to file_systems list.
+file_systems, file_systems_ids = get_file_systems()
 
-# Test with two different fsspec file systems (above).
+
+# Test with different fsspec file systems (above).
 @pytest.fixture(
     name="set_up_tb_no_cleanup",
     params=file_systems,

--- a/weave/tests/test_pytest.py
+++ b/weave/tests/test_pytest.py
@@ -20,17 +20,22 @@ import s3fs
 from weave.tests.pytest_resources import PantryForTest
 
 
-s3 = s3fs.S3FileSystem(
-    client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
-)
-local_fs = LocalFileSystem()
+file_systems = [LocalFileSystem()]
+file_systems_ids = ["LocalFileSystem"]
+if "S3_ENDPOINT" in os.environ:
+    s3 = s3fs.S3FileSystem(
+        client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
+    )
+    file_systems.append(s3)
+    file_systems_ids.append("S3FileSystem")
+
 
 
 # Test with two different fsspec file systems (above).
 @pytest.fixture(
     name="set_up_tb_no_cleanup",
-    params=[s3, local_fs],
-    ids=["S3FileSystem", "LocalFileSystem"],
+    params=file_systems,
+    ids=file_systems_ids,
 )
 def fixture_set_up_tb_no_cleanup(request, tmpdir):
     """Sets up test basket fixture."""

--- a/weave/tests/test_validate.py
+++ b/weave/tests/test_validate.py
@@ -5,13 +5,11 @@ import os
 from pathlib import Path
 
 import pytest
-import s3fs
-from fsspec.implementations.local import LocalFileSystem
 
 from weave import validate
 from weave.pantry import Pantry
 from weave.index.index_pandas import IndexPandas
-from weave.tests.pytest_resources import PantryForTest
+from weave.tests.pytest_resources import PantryForTest, get_file_systems
 
 # This module is long and has many tests. Pylint is complaining that it is too
 # long, and has too many local variables throughout each test.
@@ -180,17 +178,11 @@ class ValidateForTest(PantryForTest):
 # point in the future the two need to differentiated.
 # pylint: disable=duplicate-code
 
-file_systems = [LocalFileSystem()]
-file_systems_ids = ["LocalFileSystem"]
-if "S3_ENDPOINT" in os.environ:
-    s3 = s3fs.S3FileSystem(
-        client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
-    )
-    file_systems.append(s3)
-    file_systems_ids.append("S3FileSystem")
+# Create fsspec objects to be tested, and add to file_systems list.
+file_systems, file_systems_ids = get_file_systems()
 
 
-# Test with two different fsspec file systems (above).
+# Test with different fsspec file systems (above).
 @pytest.fixture(
     name="test_validate",
     params=file_systems,

--- a/weave/tests/test_validate.py
+++ b/weave/tests/test_validate.py
@@ -180,17 +180,21 @@ class ValidateForTest(PantryForTest):
 # point in the future the two need to differentiated.
 # pylint: disable=duplicate-code
 
-s3 = s3fs.S3FileSystem(
-    client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
-)
-local_fs = LocalFileSystem()
+file_systems = [LocalFileSystem()]
+file_systems_ids = ["LocalFileSystem"]
+if "S3_ENDPOINT" in os.environ:
+    s3 = s3fs.S3FileSystem(
+        client_kwargs={"endpoint_url": os.environ["S3_ENDPOINT"]}
+    )
+    file_systems.append(s3)
+    file_systems_ids.append("S3FileSystem")
 
 
 # Test with two different fsspec file systems (above).
 @pytest.fixture(
     name="test_validate",
-    params=[s3, local_fs],
-    ids=["S3FileSystem", "LocalFileSystem"],
+    params=file_systems,
+    ids=file_systems_ids,
 )
 def fixture_test_validate(request, tmpdir):
     """Pytest fixture for testing validate."""

--- a/weave/upload.py
+++ b/weave/upload.py
@@ -256,7 +256,10 @@ class UploadBasket:
         # I think it is wise to ignore pylint here because we should only
         # set self.file_system *after* we have sanitized it.
         # pylint: disable-next=attribute-defined-outside-init
-        self.file_system = self.kwargs.get("file_system", get_file_system())
+        self.file_system = self.kwargs.get("file_system", None)
+        if self.file_system is None:
+            # pylint: disable-next=attribute-defined-outside-init
+            self.file_system = get_file_system()
         # pylint: disable-next=attribute-defined-outside-init
         self.source_file_system = self.kwargs.get(
             "source_file_system", LocalFileSystem()


### PR DESCRIPTION
Fixes issues where we pass in a fsspec object but config.get_file_system still attempts to connect to a non-existent s3fs, 
Also fixes test files that required an S3 connection without the connection actually being necessary for the sake of the tests.