### PR TITLE
OPAL-547

### DIFF
--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -26,7 +26,7 @@ from .index.index_sql import IndexSQL
 from .pantry import Pantry
 from .mongo_loader import MongoLoader
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"
 
 __all__ = [
     "Basket",

--- a/weave/index/index_abc.py
+++ b/weave/index/index_abc.py
@@ -66,12 +66,12 @@ class IndexABC(abc.ABC):
         """
 
     @abc.abstractmethod
-    def to_pandas_df(self, max_rows=1000, offset=0, **kwargs):
+    def to_pandas_df(self, max_rows=None, offset=0, **kwargs):
         """Returns the pandas dataframe representation of the index.
 
         Parameters
         ----------
-        max_rows: int or None (default=1000)
+        max_rows: int or None (default=None)
             Max rows returned in the pandas dataframe. If None, all rows will
             be returned.
         offset: int (default=0)
@@ -162,7 +162,7 @@ class IndexABC(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_baskets_of_type(self, basket_type, max_rows=1000,
+    def get_baskets_of_type(self, basket_type, max_rows=None,
                             offset=0, **kwargs):
         """Returns a pandas dataframe containing baskets of basket_type.
 
@@ -170,7 +170,7 @@ class IndexABC(abc.ABC):
         ----------
         basket_type: str
             The basket type to filter for.
-        max_rows: int or None (default=1000)
+        max_rows: int or None (default=None)
             Max rows returned in the pandas dataframe. If None, all rows will
             be returned.
         offset: int (default=0)
@@ -184,7 +184,7 @@ class IndexABC(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_baskets_of_label(self, basket_label, max_rows=1000,
+    def get_baskets_of_label(self, basket_label, max_rows=None,
                              offset=0, **kwargs):
         """Returns a pandas dataframe containing baskets with label.
 
@@ -192,7 +192,7 @@ class IndexABC(abc.ABC):
         ----------
         basket_label: str
             The label to filter for.
-        max_rows: int or None (default=1000)
+        max_rows: int or None (default=None)
             Max rows returned in the pandas dataframe. If None, all rows will
             be returned.
         offset: int (default=0)
@@ -208,7 +208,7 @@ class IndexABC(abc.ABC):
 
     @abc.abstractmethod
     def get_baskets_by_upload_time(self, start_time=None, end_time=None,
-                                   max_rows=1000, offset=0, **kwargs):
+                                   max_rows=None, offset=0, **kwargs):
         """Returns a pandas dataframe of baskets uploaded between two times.
 
         Parameters
@@ -219,7 +219,7 @@ class IndexABC(abc.ABC):
         end_time: datetime.datetime (default=None)
             The end datetime object to filter between. If None, will filter
             to the current datetime.
-        max_rows: int or None (default=1000)
+        max_rows: int or None (default=None)
             Max rows returned in the pandas dataframe. If None, all rows will
             be returned.
         offset: int (default=0)

--- a/weave/index/index_pandas.py
+++ b/weave/index/index_pandas.py
@@ -31,7 +31,7 @@ def slice_df(df, max_rows=None, offset=0):
         Returns a slice of the dataframe.
     """
     if max_rows is None:
-        return df
+        return df.copy()
     return df.iloc[offset:offset+max_rows]
 
 
@@ -143,12 +143,12 @@ class IndexPandas(IndexABC):
         path = str(path)
         return int(os.path.basename(path).replace("-index.json",""))
 
-    def to_pandas_df(self, max_rows=1000, offset=0, **kwargs):
+    def to_pandas_df(self, max_rows=None, offset=0, **kwargs):
         """Returns the pandas dataframe representation of the index.
 
         Parameters
         ----------
-        max_rows: int or None (default=1000)
+        max_rows: int or None (default=None)
             Max rows returned in the pandas dataframe. If None, all rows will
             be returned.
         offset: int (default=0)
@@ -527,7 +527,7 @@ class IndexPandas(IndexABC):
                       ]
         return rows
 
-    def get_baskets_of_type(self, basket_type, max_rows=1000,
+    def get_baskets_of_type(self, basket_type, max_rows=None,
                             offset=0, **kwargs):
         """Returns a pandas dataframe containing baskets of basket_type.
 
@@ -535,7 +535,7 @@ class IndexPandas(IndexABC):
         ----------
         basket_type: str
             The basket type to filter for.
-        max_rows: int or None (default=1000)
+        max_rows: int or None (default=None)
             Max rows returned in the pandas dataframe. If None, all rows will
             be returned.
         offset: int (default=0)
@@ -554,7 +554,7 @@ class IndexPandas(IndexABC):
             max_rows,
             offset)
 
-    def get_baskets_of_label(self, basket_label, max_rows=1000,
+    def get_baskets_of_label(self, basket_label, max_rows=None,
                              offset=0, **kwargs):
         """Returns a pandas dataframe containing baskets with label.
 
@@ -562,7 +562,7 @@ class IndexPandas(IndexABC):
         ----------
         basket_label: str
             The label to filter for.
-        max_rows: int or None (default=1000)
+        max_rows: int or None (default=None)
             Max rows returned in the pandas dataframe. If None, all rows will
             be returned.
         offset: int (default=0)
@@ -583,7 +583,7 @@ class IndexPandas(IndexABC):
             offset)
 
     def get_baskets_by_upload_time(self, start_time=None, end_time=None,
-                                   max_rows=1000, offset=0, **kwargs):
+                                   max_rows=None, offset=0, **kwargs):
         """Returns a pandas dataframe of baskets uploaded between two times.
 
         Parameters
@@ -594,7 +594,7 @@ class IndexPandas(IndexABC):
         end_time: datetime.datetime (optional)
             The end datetime object to filter between. If None, will filter
             to the current datetime.
-        max_rows: int or None (default=1000)
+        max_rows: int or None (default=None)
             Max rows returned in the pandas dataframe. If None, all rows will
             be returned.
         offset: int (default=0)

--- a/weave/index/index_sql.py
+++ b/weave/index/index_sql.py
@@ -268,12 +268,12 @@ class IndexSQL(IndexABC):
             if len(self.get_rows(entry['uuid'].iloc[0])) == 0:
                 self.track_basket(entry)
 
-    def to_pandas_df(self, max_rows=1000, offset=0, **kwargs):
+    def to_pandas_df(self, max_rows=None, offset=0, **kwargs):
         """Returns the pandas dataframe representation of the index.
 
         Parameters
         ----------
-        max_rows: int or None (default=1000)
+        max_rows: int or None (default=None)
             Max rows returned in the pandas dataframe. If None, all rows will
             be returned.
         offset: int (default=0)
@@ -657,7 +657,7 @@ class IndexSQL(IndexABC):
 
         return child_df
 
-    def get_baskets_of_type(self, basket_type, max_rows=1000,
+    def get_baskets_of_type(self, basket_type, max_rows=None,
                             offset=0, **kwargs):
         """Returns a pandas dataframe containing baskets of basket_type.
 
@@ -665,7 +665,7 @@ class IndexSQL(IndexABC):
         ----------
         basket_type: str
             The basket type to filter for.
-        max_rows: int or None (default=1000)
+        max_rows: int or None (default=None)
             Max rows returned in the pandas dataframe. If None, all rows will
             be returned.
         offset: int (default=0)
@@ -707,7 +707,7 @@ class IndexSQL(IndexABC):
         )
         return ind_df
 
-    def get_baskets_of_label(self, basket_label, max_rows=1000,
+    def get_baskets_of_label(self, basket_label, max_rows=None,
                              offset=0, **kwargs):
         """Returns a pandas dataframe containing baskets with label.
 
@@ -715,7 +715,7 @@ class IndexSQL(IndexABC):
         ----------
         basket_label: str
             The label to filter for.
-        max_rows: int or None (default=1000)
+        max_rows: int or None (default=None)
             Max rows returned in the pandas dataframe. If None, all rows will
             be returned.
         offset: int (default=0)
@@ -758,7 +758,7 @@ class IndexSQL(IndexABC):
         return ind_df
 
     def get_baskets_by_upload_time(self, start_time=None, end_time=None,
-                                   max_rows=1000, offset=0, **kwargs):
+                                   max_rows=None, offset=0, **kwargs):
         """Returns a pandas dataframe of baskets uploaded between two times.
 
         Parameters
@@ -769,7 +769,7 @@ class IndexSQL(IndexABC):
         end_time: datetime.datetime (optional)
             The end datetime object to filter between. If None, will filter
             to the current datetime.
-        max_rows: int or None (default=1000)
+        max_rows: int or None (default=None)
             Max rows returned in the pandas dataframe. If None, all rows will
             be returned.
         offset: int (default=0)

--- a/weave/index/index_sqlite.py
+++ b/weave/index/index_sqlite.py
@@ -108,12 +108,12 @@ class IndexSQLite(IndexABC):
 
         self.con.commit()
 
-    def to_pandas_df(self, max_rows=1000, offset=0, **kwargs):
+    def to_pandas_df(self, max_rows=None, offset=0, **kwargs):
         """Returns the pandas dataframe representation of the index.
 
         Parameters
         ----------
-        max_rows: int or None (default=1000)
+        max_rows: int or None (default=None)
             Max rows returned in the pandas dataframe. If None, all rows will
             be returned.
         offset: int (default=0)
@@ -457,7 +457,7 @@ class IndexSQLite(IndexABC):
 
         return child_df
 
-    def get_baskets_of_type(self, basket_type, max_rows=1000,
+    def get_baskets_of_type(self, basket_type, max_rows=None,
                             offset=0, **kwargs):
         """Returns a pandas dataframe containing baskets of basket_type.
 
@@ -465,7 +465,7 @@ class IndexSQLite(IndexABC):
         ----------
         basket_type: str
             The basket type to filter for.
-        max_rows: int or None (default=1000)
+        max_rows: int or None (default=None)
             Max rows returned in the pandas dataframe. If None, all rows will
             be returned.
         offset: int (default=0)
@@ -501,7 +501,7 @@ class IndexSQLite(IndexABC):
         )
         return ind_df
 
-    def get_baskets_of_label(self, basket_label, max_rows=1000,
+    def get_baskets_of_label(self, basket_label, max_rows=None,
                              offset=0, **kwargs):
         """Returns a pandas dataframe containing baskets with label.
 
@@ -509,7 +509,7 @@ class IndexSQLite(IndexABC):
         ----------
         basket_label: str
             The label to filter for.
-        max_rows: int or None (default=1000)
+        max_rows: int or None (default=None)
             Max rows returned in the pandas dataframe. If None, all rows will
             be returned.
         offset: int (default=0)
@@ -546,7 +546,7 @@ class IndexSQLite(IndexABC):
         return ind_df
 
     def get_baskets_by_upload_time(self, start_time=None, end_time=None,
-                                   max_rows=1000, offset=0, **kwargs):
+                                   max_rows=None, offset=0, **kwargs):
         """Returns a pandas dataframe of baskets uploaded between two times.
 
         Parameters
@@ -557,7 +557,7 @@ class IndexSQLite(IndexABC):
         end_time: datetime.datetime (optional)
             The end datetime object to filter between. If None, will filter
             to the current datetime.
-        max_rows: int or None (default=1000)
+        max_rows: int or None (default=None)
             Max rows returned in the pandas dataframe.
         offset: int (default=0)
             Offset from the beginning of the index to begin the query

--- a/weave/pantry.py
+++ b/weave/pantry.py
@@ -277,7 +277,7 @@ class Pantry():
 
         if kwargs.get("FORCE_LOAD_SUPPLEMENT", False):
             mongo_loader.load_mongo_supplement(
-                self.index.to_pandas_df(max_rows=None).uuids
+                self.index.to_pandas_df(max_rows).uuids
             )
 
         supplement_collection = mongo_loader.database['supplement']

--- a/weave/pantry.py
+++ b/weave/pantry.py
@@ -277,7 +277,7 @@ class Pantry():
 
         if kwargs.get("FORCE_LOAD_SUPPLEMENT", False):
             mongo_loader.load_mongo_supplement(
-                self.index.to_pandas_df(max_rows).uuids
+                self.index.to_pandas_df().uuids
             )
 
         supplement_collection = mongo_loader.database['supplement']

--- a/weave/tests/test_basket.py
+++ b/weave/tests/test_basket.py
@@ -102,22 +102,22 @@ def test_make_basket_with_uuid_stays_in_pantry(test_pantry):
 
     # Save and delete the basket.
     pantry.index.generate_index()
-    index = pantry.index.to_pandas_df()
-    pantry.index.untrack_basket(index.iloc[0].uuid)
+    index_df = pantry.index.to_pandas_df()
+    pantry.index.untrack_basket(index_df.iloc[0].uuid)
 
     # Modify the basket address to a new (fake) pantry.
-    address = index.iloc[0].address
+    address = index_df.iloc[0].address
     address = address.split(os.path.sep)
     address[0] += "-2"
     new_address = (os.path.sep).join(address)
-    index.at[0,"address"] = new_address
+    index_df.at[0,"address"] = new_address
 
     # Track the new basket
-    pantry.index.track_basket(index)
+    pantry.index.track_basket(index_df)
 
     error_msg = f"Attempting to access basket outside of pantry: {new_address}"
     with pytest.raises(ValueError, match=re.escape(error_msg)):
-        Basket(index.iloc[0].uuid, pantry=pantry)
+        Basket(index_df.iloc[0].uuid, pantry=pantry)
 
 
 def test_basket_no_manifest_file(test_pantry):

--- a/weave/tests/test_index.py
+++ b/weave/tests/test_index.py
@@ -294,7 +294,7 @@ def test_index_abc_to_pandas_df_max_rows_none_works(test_pantry):
     # Generate the index.
     ind.generate_index()
 
-    baskets = ind.to_pandas_df(max_rows=None)
+    baskets = ind.to_pandas_df()
     assert len(baskets) == 3
 
 
@@ -1488,7 +1488,7 @@ def test_index_abc_get_baskets_of_type_max_rows_none_works(test_pantry):
     # Generate the index.
     ind.generate_index()
 
-    baskets = ind.get_baskets_of_type("test_basket", max_rows=None)
+    baskets = ind.get_baskets_of_type("test_basket")
     assert len(baskets) == 3
 
 
@@ -1581,7 +1581,7 @@ def test_index_abc_get_baskets_of_label_max_rows_none_works(test_pantry):
     # Generate the index.
     ind.generate_index()
 
-    baskets = ind.get_baskets_of_label("good_label", max_rows=None)
+    baskets = ind.get_baskets_of_label("good_label")
     assert len(baskets) == 3
 
 


### PR DESCRIPTION
changed all default max_rows to None and updated slice_df to stop failing pytests