### PR TITLE
OPAL-544

### DIFF
--- a/.github/workflows/pytest_and_ruff.yml
+++ b/.github/workflows/pytest_and_ruff.yml
@@ -94,6 +94,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: chartboost/ruff-action@v1
       with:
+        version: 0.4.10
         args: --extend-select=E
 
   pylint:

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -28,7 +28,7 @@ from .pantry_factory import create_pantry
 from .mongo_loader import MongoLoader
 
 
-__version__ = "1.9.1"
+__version__ = "1.9.2"
 
 
 __all__ = [

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -28,7 +28,7 @@ from .pantry_factory import create_pantry
 from .mongo_loader import MongoLoader
 
 
-__version__ = "1.9.2"
+__version__ = "1.9.3"
 
 
 __all__ = [

--- a/weave/index/index_sql.py
+++ b/weave/index/index_sql.py
@@ -249,22 +249,12 @@ class IndexSQL(IndexABC):
         ----------
         **kwargs unused for this function.
         """
+        index_df = create_index_from_fs(self.pantry_path, self.file_system)
+        index_address = index_df.address.tolist()
 
-        if not isinstance(self.pantry_path, str):
-            raise TypeError("'pantry_path' must be a string: "
-                            f"'{self.pantry_path}'")
+        for address in index_address:
+            entry = create_index_from_fs(address,file_system=self.file_system)
 
-        if not self.file_system.exists(self.pantry_path):
-            raise FileNotFoundError("'pantry_path' does not exist: "
-                                    f"'{self.pantry_path}'")
-
-        basket_jsons = [x for x in self.file_system.find(self.pantry_path)
-            if x.endswith("basket_manifest.json")
-        ]
-
-        for basket_json_address in basket_jsons:
-            entry = create_index_from_fs(basket_json_address,
-                                         file_system=self.file_system)
             if len(self.get_rows(entry['uuid'].iloc[0])) == 0:
                 self.track_basket(entry)
 

--- a/weave/index/index_sql.py
+++ b/weave/index/index_sql.py
@@ -249,14 +249,24 @@ class IndexSQL(IndexABC):
         ----------
         **kwargs unused for this function.
         """
-        index_df = create_index_from_fs(self.pantry_path, self.file_system)
-        index_address = index_df.address.tolist()
+        if not isinstance(self.pantry_path, str):
+            raise TypeError("'pantry_path' must be a string: "
+                            f"'{self.pantry_path}'")
 
-        for address in index_address:
-            entry = create_index_from_fs(address,file_system=self.file_system)
+        if not self.file_system.exists(self.pantry_path):
+            raise FileNotFoundError("'pantry_path' does not exist: "
+                                    f"'{self.pantry_path}'")
 
-            if len(self.get_rows(entry['uuid'].iloc[0])) == 0:
-                self.track_basket(entry)
+        basket_jsons = [x for x in self.file_system.find(self.pantry_path)
+            if x.endswith("basket_manifest.json")
+        ]
+
+        for basket_json_address in basket_jsons:
+            entry = create_index_from_fs(basket_json_address,
+                                         file_system=self.file_system)
+            if not entry.empty:
+                if len(self.get_rows(entry['uuid'].iloc[0])) == 0:
+                    self.track_basket(entry)
 
     def to_pandas_df(self, max_rows=None, offset=0, **kwargs):
         """Returns the pandas dataframe representation of the index.

--- a/weave/index/index_sqlite.py
+++ b/weave/index/index_sqlite.py
@@ -97,14 +97,15 @@ class IndexSQLite(IndexABC):
             raise FileNotFoundError("'pantry_path' does not exist: "
                                     f"'{self.pantry_path}'")
 
-        index_df = create_index_from_fs(self.pantry_path, self.file_system)
-        index_address = index_df.address.tolist()
+        basket_jsons = _get_list_of_basket_jsons(self.pantry_path,
+                                                 self.file_system)
 
-        for address in index_address:
-            entry = create_index_from_fs(address,file_system=self.file_system)
-
-            if len(self.get_rows(entry['uuid'].iloc[0])) == 0:
-                self.track_basket(entry, _commit_db=False)
+        for basket_json_address in basket_jsons:
+            entry = create_index_from_fs(basket_json_address,
+                                         file_system=self.file_system)
+            if not entry.empty:
+                if len(self.get_rows(entry['uuid'].iloc[0])) == 0:
+                    self.track_basket(entry, _commit_db=False)
 
         self.con.commit()
 

--- a/weave/index/index_sqlite.py
+++ b/weave/index/index_sqlite.py
@@ -97,15 +97,14 @@ class IndexSQLite(IndexABC):
             raise FileNotFoundError("'pantry_path' does not exist: "
                                     f"'{self.pantry_path}'")
 
-        basket_jsons = _get_list_of_basket_jsons(self.pantry_path,
-                                                 self.file_system)
+        index_df = create_index_from_fs(self.pantry_path, self.file_system)
+        index_address = index_df.address.tolist()
 
-        for basket_json_address in basket_jsons:
-            entry = create_index_from_fs(basket_json_address,
-                                         file_system=self.file_system)
-            if not entry.empty:
-                if len(self.get_rows(entry['uuid'].iloc[0])) == 0:
-                    self.track_basket(entry, _commit_db=False)
+        for address in index_address:
+            entry = create_index_from_fs(address,file_system=self.file_system)
+
+            if len(self.get_rows(entry['uuid'].iloc[0])) == 0:
+                self.track_basket(entry, _commit_db=False)
 
         self.con.commit()
 

--- a/weave/index/index_sqlite.py
+++ b/weave/index/index_sqlite.py
@@ -89,14 +89,23 @@ class IndexSQLite(IndexABC):
         ----------
         **kwargs unused for this function.
         """
-        index_df = create_index_from_fs(self.pantry_path, self.file_system)
-        index_address = index_df.address.tolist()
+        if not isinstance(self.pantry_path, str):
+            raise TypeError("'pantry_path' must be a string: "
+                            f"'{self.pantry_path}'")
 
-        for address in index_address:
-            entry = create_index_from_fs(address,file_system=self.file_system)
+        if not self.file_system.exists(self.pantry_path):
+            raise FileNotFoundError("'pantry_path' does not exist: "
+                                    f"'{self.pantry_path}'")
 
-            if len(self.get_rows(entry['uuid'].iloc[0])) == 0:
-                self.track_basket(entry, _commit_db=False)
+        basket_jsons = _get_list_of_basket_jsons(self.pantry_path,
+                                                 self.file_system)
+
+        for basket_json_address in basket_jsons:
+            entry = create_index_from_fs(basket_json_address,
+                                         file_system=self.file_system)
+            if not entry.empty:
+                if len(self.get_rows(entry['uuid'].iloc[0])) == 0:
+                    self.track_basket(entry, _commit_db=False)
 
         self.con.commit()
 

--- a/weave/index/index_sqlite.py
+++ b/weave/index/index_sqlite.py
@@ -89,20 +89,12 @@ class IndexSQLite(IndexABC):
         ----------
         **kwargs unused for this function.
         """
-        if not isinstance(self.pantry_path, str):
-            raise TypeError("'pantry_path' must be a string: "
-                            f"'{self.pantry_path}'")
+        index_df = create_index_from_fs(self.pantry_path, self.file_system)
+        index_address = index_df.address.tolist()
 
-        if not self.file_system.exists(self.pantry_path):
-            raise FileNotFoundError("'pantry_path' does not exist: "
-                                    f"'{self.pantry_path}'")
+        for address in index_address:
+            entry = create_index_from_fs(address,file_system=self.file_system)
 
-        basket_jsons = _get_list_of_basket_jsons(self.pantry_path,
-                                                 self.file_system)
-
-        for basket_json_address in basket_jsons:
-            entry = create_index_from_fs(basket_json_address,
-                                         file_system=self.file_system)
             if len(self.get_rows(entry['uuid'].iloc[0])) == 0:
                 self.track_basket(entry, _commit_db=False)
 

--- a/weave/tests/test_index.py
+++ b/weave/tests/test_index.py
@@ -1897,3 +1897,26 @@ def test_read_only_generate_index(test_pantry):
         os.remove(f"weave-{remove_path}.db")
     if os.path.exists(f"weave-{read_only_pantry_path}.db"):
         os.remove(f"weave-{read_only_pantry_path}.db")
+
+
+def test_generate_index_when_pandas_index_exists(test_pantry):
+    """Test that there is no error when calling generate_index() with any index
+    when there is an existing Pandas index.
+    """
+    test_pantry, ind = test_pantry
+    # Create a pandas index
+    pantry = Pantry(IndexPandas,
+                    pantry_path=test_pantry.pantry_path,
+                    file_system=test_pantry.file_system,
+                    sync=True,
+                   )
+    pantry.index.generate_index()
+    # Create other index to generate index
+    pantry2 = Pantry(type(ind),
+                    pantry_path=test_pantry.pantry_path,
+                    file_system=test_pantry.file_system,
+                    sync=True,
+                   )
+    # Generate the index.
+    pantry2.index.generate_index()
+    assert len(pantry2.index) == 0

--- a/weave/tests/test_index.py
+++ b/weave/tests/test_index.py
@@ -1911,12 +1911,14 @@ def test_generate_index_when_pandas_index_exists(test_pantry):
                     sync=True,
                    )
     pantry.index.generate_index()
-    # Create other index to generate index
+    # Create other index to generate index for test
     pantry2 = Pantry(type(ind),
                     pantry_path=test_pantry.pantry_path,
                     file_system=test_pantry.file_system,
                     sync=True,
                    )
-    # Generate the index.
-    pantry2.index.generate_index()
-    assert len(pantry2.index) == 0
+    # Generate the index; test fails if IndexError is thrown
+    try:
+        pantry2.index.generate_index()
+    except:
+        assert False

--- a/weave/tests/test_index.py
+++ b/weave/tests/test_index.py
@@ -1920,5 +1920,5 @@ def test_generate_index_when_pandas_index_exists(test_pantry):
     # Generate the index; test fails if IndexError is thrown
     try:
         pantry2.index.generate_index()
-    except:
+    except IndexError:
         assert False


### PR DESCRIPTION
The error was happening because we were trying to index an empty df in index_sql/lite - specifically, the 'entry' df in generate_index() was empty because we were calling create_index_from_fs and giving it the path of only a json file with an index basket type so it was returning an empty df. 

The hot fix was to just skip track_basket when the df was empty. 

I've tried finding a better solution but I am still new to the sql backend and weave  - I am open to better ideas! 