### PR TITLE
OPAL-550 (Save config file, and use it during create_pantry)

### DIFF
--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -27,7 +27,7 @@ from .pantry import Pantry
 from .pantry_factory import create_pantry
 from .mongo_loader import MongoLoader
 
-__version__ = "1.9.3"
+__version__ = "1.10.0"
 
 __all__ = [
     "Basket",

--- a/weave/config.py
+++ b/weave/config.py
@@ -122,6 +122,7 @@ def get_mongo_db():
             host=os.environ["MONGODB_HOST"],
             username=os.environ["MONGODB_USERNAME"],
             password=os.environ["MONGODB_PASSWORD"],
+            port=os.environ.get("MONGODB_PORT", 27017),
         )
     else:
         client = pymongo.MongoClient(

--- a/weave/index/index_abc.py
+++ b/weave/index/index_abc.py
@@ -26,7 +26,7 @@ class IndexABC(abc.ABC):
         self._file_system = file_system
         self._pantry_path = pantry_path
         self.config_metadata = kwargs.get("config_metadata", {})
-        self.generate_metadata()
+        self.generate_config()
 
     @property
     @abc.abstractmethod

--- a/weave/index/index_abc.py
+++ b/weave/index/index_abc.py
@@ -39,7 +39,7 @@ class IndexABC(abc.ABC):
         """The pantry path referenced by this Index."""
 
     @abc.abstractmethod
-    def generate_metadata(self, **kwargs):
+    def generate_config(self, **kwargs):
         """Generate the metadata for the index.
 
         Parameters
@@ -51,7 +51,7 @@ class IndexABC(abc.ABC):
         A dictionary of metadata for the index.
         """
 
-        self.metadata["name"] = str(self)
+        self.config_metadata["index_type"] = str(self)
 
     @abc.abstractmethod
     def generate_index(self, **kwargs):

--- a/weave/index/index_abc.py
+++ b/weave/index/index_abc.py
@@ -18,14 +18,14 @@ class IndexABC(abc.ABC):
             The fsspec object which hosts the pantry we desire to index.
         pantry_path: str
             Path to the pantry root which we want to index.
-        **metadata: dict (required)
+        **config_metadata: dict (required)
             Existing metadata for the Index.
         Optional kwargs controlled by concrete implementations.
         """
 
         self._file_system = file_system
         self._pantry_path = pantry_path
-        self.metadata = kwargs.get("metadata", {})
+        self.config_metadata = kwargs.get("config_metadata", {})
         self.generate_metadata()
 
     @property

--- a/weave/index/index_abc.py
+++ b/weave/index/index_abc.py
@@ -2,6 +2,7 @@
 """
 
 import abc
+import warnings
 from datetime import datetime
 
 
@@ -18,14 +19,14 @@ class IndexABC(abc.ABC):
             The fsspec object which hosts the pantry we desire to index.
         pantry_path: str
             Path to the pantry root which we want to index.
-        **config_metadata: dict (required)
+        **setup_config: dict (required)
             Existing metadata for the Index.
         Optional kwargs controlled by concrete implementations.
         """
 
         self._file_system = file_system
         self._pantry_path = pantry_path
-        self.config_metadata = kwargs.get("config_metadata", {})
+        self.setup_config = kwargs.get("setup_config", {})
         self.generate_config()
 
     @property
@@ -39,8 +40,17 @@ class IndexABC(abc.ABC):
         """The pantry path referenced by this Index."""
 
     @abc.abstractmethod
+    def generate_metadata(self, **kwargs):
+        """(Deprecated) Generate the metadata for the index."""
+        warnings.warn(
+            UserWarning("This function is being deprecated in a future weave "
+                        "release. Please use generate_config() instead.")
+        )
+        return self.generate_config(**kwargs)
+
+    @abc.abstractmethod
     def generate_config(self, **kwargs):
-        """Generate the metadata for the index.
+        """Generate the setup config for the index.
 
         Parameters
         ----------
@@ -50,8 +60,7 @@ class IndexABC(abc.ABC):
         ----------
         A dictionary of metadata for the index.
         """
-
-        self.config_metadata["index_type"] = str(self)
+        self.setup_config["index_type"] = str(self)
 
     @abc.abstractmethod
     def generate_index(self, **kwargs):

--- a/weave/index/index_pandas.py
+++ b/weave/index/index_pandas.py
@@ -107,6 +107,14 @@ class IndexPandas(IndexABC):
             return False
         return True
 
+    def generate_metadata(self, **kwargs):
+        """(Deprecated) Generate the metadata for the index."""
+        warnings.warn(
+            UserWarning("This function is being deprecated in a future weave "
+                        "release. Please use generate_config() instead.")
+        )
+        return self.generate_config(**kwargs)
+
     def generate_config(self, **kwargs):
         """Populates the metadata for the index.
 
@@ -115,7 +123,7 @@ class IndexPandas(IndexABC):
         **kwargs unused for this class.
         """
         super().generate_config(**kwargs)
-        return self.config_metadata
+        return self.setup_config
 
     def sync_index(self):
         """Gets index from latest index basket."""

--- a/weave/index/index_pandas.py
+++ b/weave/index/index_pandas.py
@@ -107,15 +107,15 @@ class IndexPandas(IndexABC):
             return False
         return True
 
-    def generate_metadata(self, **kwargs):
+    def generate_config(self, **kwargs):
         """Populates the metadata for the index.
 
         Parameters
         ----------
         **kwargs unused for this class.
         """
-        super().generate_metadata(**kwargs)
-        return self.metadata
+        super().generate_config(**kwargs)
+        return self.config_metadata
 
     def sync_index(self):
         """Gets index from latest index basket."""

--- a/weave/index/index_sql.py
+++ b/weave/index/index_sql.py
@@ -220,6 +220,14 @@ class IndexSQL(IndexABC):
         """The pantry path referenced by this Index."""
         return self._pantry_path
 
+    def generate_metadata(self, **kwargs):
+        """(Deprecated) Generate the metadata for the index."""
+        warnings.warn(
+            UserWarning("This function is being deprecated in a future weave "
+                        "release. Please use generate_config() instead.")
+        )
+        return self.generate_config(**kwargs)
+
     def generate_config(self, **kwargs):
         """Populates the metadata for the index.
 

--- a/weave/index/index_sql.py
+++ b/weave/index/index_sql.py
@@ -220,7 +220,7 @@ class IndexSQL(IndexABC):
         """The pantry path referenced by this Index."""
         return self._pantry_path
 
-    def generate_metadata(self, **kwargs):
+    def generate_config(self, **kwargs):
         """Populates the metadata for the index.
 
         Parameters

--- a/weave/index/index_sqlite.py
+++ b/weave/index/index_sqlite.py
@@ -70,6 +70,14 @@ class IndexSQLite(IndexABC):
         """The pantry path referenced by this Index."""
         return self._pantry_path
 
+    def generate_metadata(self, **kwargs):
+        """(Deprecated) Generate the metadata for the index."""
+        warnings.warn(
+            UserWarning("This function is being deprecated in a future weave "
+                        "release. Please use generate_config() instead.")
+        )
+        return self.generate_config(**kwargs)
+
     def generate_config(self, **kwargs):
         """Populates the metadata for the index.
 

--- a/weave/index/index_sqlite.py
+++ b/weave/index/index_sqlite.py
@@ -70,7 +70,7 @@ class IndexSQLite(IndexABC):
         """The pantry path referenced by this Index."""
         return self._pantry_path
 
-    def generate_metadata(self, **kwargs):
+    def generate_config(self, **kwargs):
         """Populates the metadata for the index.
 
         Parameters

--- a/weave/mongo_loader.py
+++ b/weave/mongo_loader.py
@@ -21,17 +21,19 @@ class MongoLoader():
     mongo db based on the record type (ie supplement, manifest, metadata).
     """
 
-    def __init__(self, pantry, **kwargs):
+    def __init__(self, pantry, mongo_client=None, **kwargs):
         """Creates the mongo loader and makes a reference to the pantry's DB.
 
         Parameters
         ----------
         pantry: weave.Pantry
             A pantry object
-        **mongo_client: pymongo.MongoClient (optional)
-            A pre-constructed MongoClient to be used. If not present, a
-            MongoClient will be constructed using the optional mongo_config
-            dictionary, or weave.config.get_mongo_db() as a last resort.
+        mongo_client: pymongo.MongoClient or None (optional; defaults to None)
+            A pre-constructed MongoClient to be used. Ignored if the Pantry arg
+            has a non-None pantry.mongo_client. Otherwise, this arg will be
+            used for the client. If none, is provided, a MongoClient will be
+            constructed using the optional mongo_config dictionary,
+            or weave.config.get_mongo_db() as a last resort.
         **mongo_config: dict (optional)
             Dictionary containing the configuration settings of this loader.
             Supported Keys:
@@ -43,9 +45,9 @@ class MongoLoader():
         self.pantry = pantry
         self.mongo_config = kwargs.get("mongo_config", {})
 
-        # Try to get the mongo_client from the optional kwarg.
-        self.mongo_client = kwargs.get("mongo_client")
-        # Try to make one using the optional mongo_config, if still None.
+        # Priorize using the pantry client, otherwise use the given client.
+        self.mongo_client = self.pantry.mongo_client or mongo_client
+        # If both were None, try to make a client using the mongo_config.
         if self.mongo_client is None:
             self.mongo_client = pymongo.MongoClient(
                 host=self.mongo_config.get("mongodb_host"),

--- a/weave/pantry.py
+++ b/weave/pantry.py
@@ -1,6 +1,4 @@
-"""This class builds the user-facing Index class. It pulls from the _Index 
-class which uses Pandas as it's backend to build and interface with the on disk
-Index baskets.
+"""Wherein is contained the Pantry class.
 """
 
 import json
@@ -70,7 +68,7 @@ class Pantry():
             )
 
         self.pantry_path = str(pantry_path)
-        self.load_metadata()
+        self.load_setup_config()
 
         # Check if file system is read-only. If so, raise error.
         try:
@@ -82,13 +80,14 @@ class Pantry():
         except (OSError, ValueError):
             self.is_read_only = True
 
-        self.index = index(file_system=self.file_system,
-                           pantry_path=self.pantry_path,
-                           metadata=self.metadata['index_metadata'],
-                           pantry_read_only=self.is_read_only,
-                           **kwargs,
+        self.index = index(
+            file_system=self.file_system,
+            pantry_path=self.pantry_path,
+            config_metadata=self.config_metadata['index_setup_config'],
+            pantry_read_only=self.is_read_only,
+            **kwargs,
         )
-        self.metadata['index_metadata'] = self.index.generate_metadata()
+        self.config_metadata['index_setup_config'] = self.index.generate_config()
 
     def validate_path_in_pantry(self, path):
         """Validate the given path is within the pantry.
@@ -113,24 +112,25 @@ class Pantry():
                 f"Attempting to access basket outside of pantry: {path}"
             )
 
-    def load_metadata(self):
+    def load_setup_config(self):
         """Load pantry metadata from pantry_metadata.json."""
         self.metadata_path = os.path.join(
-                                self.pantry_path,'pantry_metadata.json'
+            self.pantry_path,
+            'pantry_metadata.json',
         )
         if self.file_system.exists(self.metadata_path):
             with self.file_system.open(self.metadata_path, "rb") as file:
                 self.metadata = json.load(file)
         else:
-            self.metadata = {}
-        if 'index_metadata' not in self.metadata:
-            self.metadata['index_metadata'] = {}
+            self.config_metadata = {}
+        if 'index_setup_config' not in self.metadata:
+            self.config_metadata['index_setup_config'] = {}
 
-    def save_metadata(self):
+    def save_setup_config(self):
         """Dump metadata to to pantry metadata file."""
-        self.metadata['index_metadata'] = self.index.metadata
+        self.pantry_setup_config['index_metadata'] = self.index.metadata
         with self.file_system.open(
-                    self.metadata_path, "w", encoding="utf-8"
+            self.metadata_path, "w", encoding="utf-8"
         ) as outfile:
             json.dump(self.metadata, outfile)
 

--- a/weave/pantry.py
+++ b/weave/pantry.py
@@ -147,17 +147,9 @@ class Pantry():
         )
         self.config_metadata["pantry_path"] = self.pantry_path
 
-        # Add the config fields for the mongo db data store if available.
-        if self.mongo_client:
-            # Prioritize user provided mongo config dictionary.
-            if self.mongo_config:
-                self.config_metadata.update(self.mongo_config)
-            # Otherwise, populate as much as we can from the mongo client.
-            else:
-                address = self.mongo_client.address
-                if address:
-                    self.config_metadata["mongodb_host"] = address[0]
-                    self.config_metadata["mongodb_port"] = address[1]
+        # Add the provided mongo_config to the main config dictionary.
+        if self.mongo_config:
+            self.config_metadata.update(self.mongo_config)
 
     def save_setup_config(self):
         """Dump metadata to to pantry metadata file."""

--- a/weave/pantry.py
+++ b/weave/pantry.py
@@ -49,6 +49,9 @@ class Pantry():
             the contents within the pantry.
         pantry_path: str (default="weave-test")
             Name of the pantry this object is associated with.
+        mongo_client: pymongo.MongoClient (optional)
+            The MongoClient object to be used to update a mongo datastore when
+            adding and removing baskets.
         **file_system: fsspec object (optional)
             The fsspec object which hosts the pantry we desire to index.
             If file_system is None, then the default fs is retrieved from the

--- a/weave/pantry.py
+++ b/weave/pantry.py
@@ -68,6 +68,7 @@ class Pantry():
             )
 
         self.pantry_path = str(pantry_path)
+        self.config_metadata = {}
         self.load_setup_config()
 
         # Check if file system is read-only. If so, raise error.
@@ -88,6 +89,7 @@ class Pantry():
             **kwargs,
         )
         self.config_metadata['index_setup_config'] = self.index.generate_config()
+        self._generate_config()
 
     def validate_path_in_pantry(self, path):
         """Validate the given path is within the pantry.
@@ -113,24 +115,30 @@ class Pantry():
             )
 
     def load_setup_config(self):
-        """Load pantry metadata from pantry_metadata.json."""
-        self.metadata_path = os.path.join(
+        """Load pantry metadata from config.json."""
+        self.config_path = os.path.join(
             self.pantry_path,
-            'pantry_metadata.json',
+            'config.json',
         )
-        if self.file_system.exists(self.metadata_path):
-            with self.file_system.open(self.metadata_path, "rb") as file:
+        if self.file_system.exists(self.config_path):
+            with self.file_system.open(self.config_path, "rb") as file:
                 self.config_metadata = json.load(file)
         else:
             self.config_metadata = {}
         if 'index_setup_config' not in self.config_metadata:
             self.config_metadata['index_setup_config'] = {}
 
+    def _generate_config(self):
+        self.config_metadata["index"] = str(self.index)
+        self.config_metadata["file_system"] = str(
+            self.file_system.__class__.__name__
+        )
+        self.config_metadata["pantry_path"] = self.pantry_path
+
     def save_setup_config(self):
         """Dump metadata to to pantry metadata file."""
-        self.pantry_setup_config['index_metadata'] = self.index.config_metadata
         with self.file_system.open(
-            self.metadata_path, "w", encoding="utf-8"
+            self.config_path, "w", encoding="utf-8"
         ) as outfile:
             json.dump(self.config_metadata, outfile)
 

--- a/weave/pantry.py
+++ b/weave/pantry.py
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 """Wherein is contained the Pantry class.
 """
 

--- a/weave/pantry.py
+++ b/weave/pantry.py
@@ -120,19 +120,19 @@ class Pantry():
         )
         if self.file_system.exists(self.metadata_path):
             with self.file_system.open(self.metadata_path, "rb") as file:
-                self.metadata = json.load(file)
+                self.config_metadata = json.load(file)
         else:
             self.config_metadata = {}
-        if 'index_setup_config' not in self.metadata:
+        if 'index_setup_config' not in self.config_metadata:
             self.config_metadata['index_setup_config'] = {}
 
     def save_setup_config(self):
         """Dump metadata to to pantry metadata file."""
-        self.pantry_setup_config['index_metadata'] = self.index.metadata
+        self.pantry_setup_config['index_metadata'] = self.index.config_metadata
         with self.file_system.open(
             self.metadata_path, "w", encoding="utf-8"
         ) as outfile:
-            json.dump(self.metadata, outfile)
+            json.dump(self.config_metadata, outfile)
 
     def validate(self):
         """Convenient wrapper function to validate the pantry.

--- a/weave/pantry_factory.py
+++ b/weave/pantry_factory.py
@@ -164,12 +164,13 @@ def _create_pantry_from_config(config, **kwargs):
                 host=config.get("mongodb_host"),
                 username=config.get("mongodb_username"),
                 password=config.get("mongodb_password"),
+                port=config.get("mongodb_port", 27017),
             )
 
     return Pantry(
         index_constructor,
         pantry_path=pantry_path,
         file_system=file_system,
-        mongo_client=mongo_client
-        **kwargs
+        mongo_client=mongo_client,
+        **kwargs,
     )

--- a/weave/pantry_factory.py
+++ b/weave/pantry_factory.py
@@ -2,10 +2,12 @@
 pre-existing config file either locally or from the pantry path."""
 import json
 import os
+import warnings
 
 import s3fs
-import warnings
 from fsspec.implementations.local import LocalFileSystem
+# Duplicate code below used to handle pymongo being unavailable.
+# pylint: disable-next=duplicate-code
 try:
     import pymongo
 except ImportError:
@@ -96,7 +98,7 @@ def create_pantry(**kwargs):
         raise ValueError("Invalid kwargs passed, unable to make pantry")
     return pantry
 
-
+# pylint: disable-next=too-many-branches
 def _create_pantry_from_config(config, **kwargs):
     """Create the weave.pantry object from a pre-existing config file.
 
@@ -161,9 +163,9 @@ def _create_pantry_from_config(config, **kwargs):
         )
         else:
             mongo_client = pymongo.MongoClient(
-                host=config.get("mongodb_host"),
-                username=config.get("mongodb_username"),
-                password=config.get("mongodb_password"),
+                host=config["mongodb_host"],
+                username=config["mongodb_username"],
+                password=config["mongodb_password"],
                 port=config.get("mongodb_port", 27017),
             )
 

--- a/weave/tests/test_index.py
+++ b/weave/tests/test_index.py
@@ -143,14 +143,14 @@ def test_index_abc_builtin_str_works(test_index_only):
     )
 
 
-def test_index_abc_generate_metadata_returns_dict(test_index_only):
-    """Test IndexABC generate_metadata returns a python dictionary."""
+def test_index_abc_generate_config_returns_dict(test_index_only):
+    """Test IndexABC generate_config returns a python dictionary."""
     ind = test_index_only
 
-    metadata = ind.generate_metadata()
+    metadata = ind.generate_config()
     assert (
         isinstance(metadata, dict)
-    ), "Index.generate_metadata must return a dict."
+    ), "Index.generate_config must return a dict."
 
 
 def test_index_abc_generate_index_works(test_pantry):

--- a/weave/tests/test_mongo_db.py
+++ b/weave/tests/test_mongo_db.py
@@ -250,8 +250,14 @@ def test_load_mongo_metadata_check_for_duplicate_uuid(set_up):
     test_uuid = "1234"
 
     mongo_loader = MongoLoader(pantry=set_up.pantry)
-    mongo_loader.load_mongo_metadata([test_uuid], set_up.metadata_collection)
-    mongo_loader.load_mongo_metadata([test_uuid], set_up.metadata_collection)
+    mongo_loader.load_mongo_metadata(
+        [test_uuid],
+        collection=set_up.metadata_collection,
+    )
+    mongo_loader.load_mongo_metadata(
+        [test_uuid],
+        collection=set_up.metadata_collection,
+    )
 
     count = set_up.database[set_up.metadata_collection].count_documents(
         {"uuid": test_uuid}
@@ -268,8 +274,14 @@ def test_load_mongo_manifest_check_for_duplicate_uuid(set_up):
     test_uuid = "1234"
 
     mongo_loader = MongoLoader(pantry=set_up.pantry)
-    mongo_loader.load_mongo_manifest([test_uuid], set_up.manifest_collection)
-    mongo_loader.load_mongo_manifest([test_uuid], set_up.manifest_collection)
+    mongo_loader.load_mongo_manifest(
+        [test_uuid],
+        collection=set_up.manifest_collection,
+    )
+    mongo_loader.load_mongo_manifest(
+        [test_uuid],
+        collection=set_up.manifest_collection,
+    )
 
     count = set_up.database[set_up.manifest_collection].count_documents(
         {"uuid": test_uuid}
@@ -289,11 +301,11 @@ def test_load_mongo_supplement_check_for_duplicate_uuid(set_up):
     mongo_loader = MongoLoader(pantry=set_up.pantry)
     mongo_loader.load_mongo_supplement(
         [test_uuid],
-        set_up.supplement_collection,
+        collection=set_up.supplement_collection,
     )
     mongo_loader.load_mongo_supplement(
         [test_uuid],
-        set_up.supplement_collection,
+        collection=set_up.supplement_collection,
     )
 
     count = set_up.database[set_up.supplement_collection].count_documents(

--- a/weave/tests/test_pantry.py
+++ b/weave/tests/test_pantry.py
@@ -557,34 +557,36 @@ def test_get_basket_stays_in_pantry(test_pantry):
         pantry.get_basket(index.iloc[0].address)
 
 
-def test_pantry_get_metadata_no_data(test_pantry):
-    """Test the pantry reads in empty metadata and the index metadata."""
+def test_pantry_get_metadata_basic_data(test_pantry):
+    """Test the pantry reads in basic metadata and the index metadata."""
     pantry = Pantry(
         IndexPandas,
         pantry_path=test_pantry.pantry_path,
         file_system=test_pantry.file_system
     )
 
-    assert len(pantry.metadata) == 1
-    assert 'index_metadata' in pantry.metadata
+    # Below are the basic keys that should always exist in a config dictionary.
+    basic_keys = ("index_setup_config", "index", "file_system", "pantry_path")
+    assert len(pantry.setup_config) == 4
+    assert all(k in pantry.setup_config for k in basic_keys)
 
 
-def test_pantry_save_metadata(test_pantry):
+def test_pantry_save_setup_config(test_pantry):
     """Test Pantry can save metadata correctly."""
     pantry = Pantry(
         IndexPandas,
         pantry_path=test_pantry.pantry_path,
         file_system=test_pantry.file_system
     )
-    pantry.save_metadata()
+    pantry.save_setup_config()
 
     file_metadata = None
-    if pantry.file_system.exists(pantry.metadata_path):
-        with pantry.file_system.open(pantry.metadata_path, "rb") as file:
+    if pantry.file_system.exists(pantry.config_path):
+        with pantry.file_system.open(pantry.config_path, "rb") as file:
             file_metadata = json.load(file)
 
-    assert pantry.file_system.exists(pantry.metadata_path)
-    assert pantry.metadata == file_metadata
+    assert pantry.file_system.exists(pantry.config_path)
+    assert pantry.setup_config == file_metadata
 
 
 def test_pantry_get_metadata_existing_data(test_pantry):
@@ -594,9 +596,9 @@ def test_pantry_get_metadata_existing_data(test_pantry):
         pantry_path=test_pantry.pantry_path,
         file_system=test_pantry.file_system
     )
-    pantry.metadata['test'] = 'test'
-    pantry.metadata['index_metadata']['test'] = 'test'
-    pantry.save_metadata()
+    pantry.setup_config['test'] = 'test'
+    pantry.setup_config['index_setup_config']['test'] = 'test'
+    pantry.save_setup_config()
 
     pantry2 = Pantry(
         IndexPandas,
@@ -604,8 +606,8 @@ def test_pantry_get_metadata_existing_data(test_pantry):
         file_system=test_pantry.file_system
     )
 
-    assert pantry2.metadata['test'] == 'test'
-    assert pantry2.index.metadata['test'] == 'test'
+    assert pantry2.setup_config['test'] == 'test'
+    assert pantry2.index.setup_config['test'] == 'test'
 
 
 def test_upload_basket_works_on_empty_basket(test_pantry):

--- a/weave/tests/test_pantry_factory.py
+++ b/weave/tests/test_pantry_factory.py
@@ -142,9 +142,9 @@ def test_pantry_factory_invalid_index(test_pantry):
         encoding="utf-8"
     ) as config_file:
         json.dump(
-            {"index":invalid_index,
-             "pantry_path":test_pantry.pantry_path,
-             "file_system":file_system_type},
+            {"index": invalid_index,
+             "pantry_path": test_pantry.pantry_path,
+             "file_system": file_system_type},
             config_file
         )
 
@@ -191,3 +191,61 @@ def test_pantry_factory_invalid_args():
         match="Invalid kwargs passed, unable to make pantry",
     ):
         create_pantry()
+
+
+def test_pantry_factory_loads_mongo_config(test_pantry):
+    """Ensure custom mongo connections are used when the proper keys exist in a
+    config file."""
+    test_pantry, index_name, index_constructor = test_pantry
+    file_system_type = test_pantry.file_system.__class__.__name__
+
+    # Create a config for custom connections and settings for mongo.
+    test_config = {
+        "mongodb_host": "mongodb",
+        "mongodb_port": 27017,
+        "mongodb_username": "root",
+        "mongodb_password": "example",
+        "metadata_collection": "test-custom-metadata",
+        "supplement_collection": "test-custom-supplement",
+        "manifest_collection": "test-custom-manifest",
+    }
+
+    # Create a pantry using the 'default' method, but give it additional mongo
+    # config settings.
+    pantry = create_pantry(
+        index=index_constructor,
+        pantry_path=test_pantry.pantry_path,
+        file_system=test_pantry.file_system,
+        mongo_config=test_config,
+    )
+
+    # Have the pantry save its config settings to the global pantry config.
+    pantry.save_setup_config()
+
+    # Check that the config was written correctly and contains all the
+    # additional mongo config settings.
+    with test_pantry.file_system.open(
+        os.path.join(test_pantry.pantry_path, "config.json")
+    ) as config_file:
+        pantry_config = json.load(config_file)
+        assert all(pantry_config.get(key, None) == val for key, val
+            in test_config.items())
+
+    # Create a pantry using the saved config.
+    pantry2 = create_pantry(
+        pantry_path=test_pantry.pantry_path,
+        file_system=test_pantry.file_system,
+        mongo_config=test_config,
+    )
+
+    # Ensure previously provided config settings are loaded from the config
+    # when a new pantry is constructed from the global config.
+    assert all(pantry2.config_metadata.get(key, None) == val for key, val
+                in test_config.items())
+
+    # Also check the index creation settings are in the loaded config.
+    assert pantry2.config_metadata.get("index") == str(pantry2.index)
+    assert pantry2.config_metadata.get("file_system") == (
+        pantry2.file_system.__class__.__name__
+    )
+    assert pantry2.config_metadata.get("pantry_path") == pantry2.pantry_path

--- a/weave/tests/test_pantry_factory.py
+++ b/weave/tests/test_pantry_factory.py
@@ -116,10 +116,10 @@ def test_pantry_factory_existing_pantry_config(test_pantry):
     ) as config_file:
         s3_endpoint = os.environ.get("S3_ENDPOINT", None)
         json.dump(
-            {"index":index_name,
-             "pantry_path":test_pantry.pantry_path,
-             "file_system":file_system_type,
-             "S3_ENDPOINT":s3_endpoint},
+            {"index": index_name,
+             "pantry_path": test_pantry.pantry_path,
+             "file_system": file_system_type,
+             "S3_ENDPOINT": s3_endpoint},
             config_file
         )
 

--- a/weave/tests/test_pantry_factory.py
+++ b/weave/tests/test_pantry_factory.py
@@ -197,7 +197,6 @@ def test_pantry_factory_loads_mongo_config(test_pantry):
     """Ensure custom mongo connections are used when the proper keys exist in a
     config file."""
     test_pantry, index_name, index_constructor = test_pantry
-    file_system_type = test_pantry.file_system.__class__.__name__
 
     # Create a config for custom connections and settings for mongo.
     test_config = {
@@ -240,12 +239,12 @@ def test_pantry_factory_loads_mongo_config(test_pantry):
 
     # Ensure previously provided config settings are loaded from the config
     # when a new pantry is constructed from the global config.
-    assert all(pantry2.config_metadata.get(key, None) == val for key, val
+    assert all(pantry2.setup_config.get(key, None) == val for key, val
                 in test_config.items())
 
     # Also check the index creation settings are in the loaded config.
-    assert pantry2.config_metadata.get("index") == str(pantry2.index)
-    assert pantry2.config_metadata.get("file_system") == (
+    assert pantry2.setup_config.get("index") == str(pantry2.index)
+    assert pantry2.setup_config.get("file_system") == (
         pantry2.file_system.__class__.__name__
     )
-    assert pantry2.config_metadata.get("pantry_path") == pantry2.pantry_path
+    assert pantry2.setup_config.get("pantry_path") == pantry2.pantry_path

--- a/weave/tests/test_pantry_factory.py
+++ b/weave/tests/test_pantry_factory.py
@@ -196,7 +196,7 @@ def test_pantry_factory_invalid_args():
 def test_pantry_factory_loads_mongo_config(test_pantry):
     """Ensure custom mongo connections are used when the proper keys exist in a
     config file."""
-    test_pantry, index_name, index_constructor = test_pantry
+    test_pantry, _, index_constructor = test_pantry
 
     # Create a config for custom connections and settings for mongo.
     test_config = {


### PR DESCRIPTION
Add functionality to save a pantry's configuration settings to a config.json file in the root of the pantry dir. 
When using create_pantry and using the global config method, automatically read in the config file and use applicable settings to create connections to mongo, create the index, etc.
