### PR TITLE
OPAL 700 (fix case sensitive pantry_schema bug)

### DIFF
--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -27,7 +27,7 @@ from .pantry import Pantry
 from .pantry_factory import create_pantry
 from .mongo_loader import MongoLoader
 
-__version__ = "1.11.0"
+__version__ = "1.11.1"
 
 __all__ = [
     "Basket",

--- a/weave/index/index_sql.py
+++ b/weave/index/index_sql.py
@@ -84,6 +84,7 @@ class IndexSQL(IndexABC):
         if d_schema_name == "":
             d_schema_name = "weave"
         self._pantry_schema = kwargs.get("pantry_schema", d_schema_name)
+        self._pantry_schema = self._pantry_schema.lower()
 
         self._engine = sqla.create_engine(sqla.engine.url.URL(
             drivername="postgresql",

--- a/weave/tests/test_index_sql.py
+++ b/weave/tests/test_index_sql.py
@@ -258,4 +258,3 @@ def test_index_sql_check_duplicate_schema_name(test_index):
     # different pantry_path casing.
     _ = IndexSQL(LocalFileSystem(), pantry_path.upper())
     _ = IndexSQL(LocalFileSystem(), pantry_path.lower())
-

--- a/weave/tests/test_index_sql.py
+++ b/weave/tests/test_index_sql.py
@@ -253,9 +253,9 @@ def test_drop_index_deletes_sql_schema(test_index):
 def test_index_sql_check_duplicate_schema_name(test_index):
     """Test that the duplicate schema error is not raised when using different
     case-sensitive paths."""
-    pantry_path = test_ind.index.pantry_path
+    pantry_path = test_index.index.pantry_path
     # Test that we can create a SQL Index using the same pantry path in
     # different pantry_path casing.
-    ind_1 = IndexSQL(LocalFileSystem(), pantry_path.upper())
-    ind_2 = IndexSQL(LocalFileSystem(), pantry_path.lower())
+    _ = IndexSQL(LocalFileSystem(), pantry_path.upper())
+    _ = IndexSQL(LocalFileSystem(), pantry_path.lower())
 

--- a/weave/tests/test_index_sql.py
+++ b/weave/tests/test_index_sql.py
@@ -241,3 +241,21 @@ def test_drop_index_deletes_sql_schema(test_index):
     # Recreate the db using clear_index so the test doesn't crash during
     # cleanup, as we previously dropped the schema.
     ind.clear_index()
+
+
+# Skip tests if sqlalchemy is not installed.
+@pytest.mark.skipif(
+    not _HAS_REQUIRED_DEPS
+    or not os.environ.get("WEAVE_SQL_PASSWORD", False),
+    reason="Modules: 'psycopg2', 'sqlalchemy' required for this test "
+    "AND env variables: 'WEAVE_SQL_HOST', 'WEAVE_SQL_PASSWORD'",
+)
+def test_index_sql_check_duplicate_schema_name(test_index):
+    """Test that the duplicate schema error is not raised when using different
+    case-sensitive paths."""
+    pantry_path = test_ind.index.pantry_path
+    # Test that we can create a SQL Index using the same pantry path in
+    # different pantry_path casing.
+    ind_1 = IndexSQL(LocalFileSystem(), pantry_path.upper())
+    ind_2 = IndexSQL(LocalFileSystem(), pantry_path.lower())
+


### PR DESCRIPTION
Fixed a bug in the IndexSQL constructor when the pantry path had non-lowercase values which sometimes resulted in a schema duplicate error