### PR TITLE
Opal 684

### DIFF
--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -27,7 +27,7 @@ from .pantry import Pantry
 from .pantry_factory import create_pantry
 from .mongo_loader import MongoLoader
 
-__version__ = "1.12.0"
+__version__ = "1.12.1"
 
 __all__ = [
     "Basket",

--- a/weave/mongo_loader.py
+++ b/weave/mongo_loader.py
@@ -10,6 +10,7 @@ except ImportError:
     _HAS_PYMONGO = False
 else:
     _HAS_PYMONGO = True
+from pathlib import Path
 
 from .basket import Basket
 from .config import get_mongo_db
@@ -64,7 +65,7 @@ class MongoLoader():
         # Get the database. (Use MONGODB_DATABASE, defaulting to
         # pantry_path if it is not present.)
         self.database_name = self.mongo_config.get(
-            "mongodb_database", self.pantry.pantry_path)
+            "mongodb_database", Path(self.pantry.pantry_path).name) 
         self.database = self.mongo_client[self.database_name]
 
         self.metadata_collection = self.mongo_config.get(

--- a/weave/mongo_loader.py
+++ b/weave/mongo_loader.py
@@ -65,7 +65,7 @@ class MongoLoader():
         # Get the database. (Use MONGODB_DATABASE, defaulting to
         # pantry_path if it is not present.)
         self.database_name = self.mongo_config.get(
-            "mongodb_database", Path(self.pantry.pantry_path).name) 
+            "mongodb_database", Path(self.pantry.pantry_path).name)
         self.database = self.mongo_client[self.database_name]
 
         self.metadata_collection = self.mongo_config.get(


### PR DESCRIPTION
In order to run the DDA locally on a GFE, you need to be able to pass in a directory path to the DDA, not just a single folder name. This change allows the user to supply a path to a local pantry when spinning up the DDA (DDA_PANTRY=/path/to/local/pantry). 

Without this change, a user must place a local pantry folder at the root of the local computer directory when spinning up the DDA.  