### PR TITLE
enforce integer env vars for port numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-<h1 align="center">
-<img src="./weave_transparent.png" width="300">
-</h1>
+<h1 align="center"><img src="./weave_transparent.png" width="300"></h1>
 
 # Weave
 

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -27,7 +27,7 @@ from .pantry import Pantry
 from .pantry_factory import create_pantry
 from .mongo_loader import MongoLoader
 
-__version__ = "1.12.2"
+__version__ = "1.12.3"
 
 __all__ = [
     "Basket",

--- a/weave/config.py
+++ b/weave/config.py
@@ -122,7 +122,7 @@ def get_mongo_db():
             host=os.environ["MONGODB_HOST"],
             username=os.environ["MONGODB_USERNAME"],
             password=os.environ["MONGODB_PASSWORD"],
-            port=os.environ.get("MONGODB_PORT", 27017),
+            port=int(os.environ.get("MONGODB_PORT", 27017)),
         )
     else:
         client = pymongo.MongoClient(

--- a/weave/index/index_sql.py
+++ b/weave/index/index_sql.py
@@ -57,7 +57,7 @@ class IndexSQL(IndexABC):
                 'host': os.environ["WEAVE_SQL_HOST"],
                 'username': os.environ["WEAVE_SQL_USERNAME"],
                 'password': os.environ["WEAVE_SQL_PASSWORD"],
-                'port': os.environ.get("WEAVE_SQL_PORT", 5432),
+                'port': int(os.environ.get("WEAVE_SQL_PORT", 5432)),
             }
             # pylint: enable=pointless-statement
         except KeyError as key_error:

--- a/weave/pantry.py
+++ b/weave/pantry.py
@@ -84,6 +84,7 @@ class Pantry():
 
         # Check if file system is read-only. If so, raise error.
         try:
+            # FIXME: this is wasteful -- nothing is ever really deleted in s3
             self.file_system.touch(os.path.join(self.pantry_path,
                                                 "test_read_only.txt"))
             self.file_system.rm(os.path.join(self.pantry_path,

--- a/weave/pantry.py
+++ b/weave/pantry.py
@@ -84,7 +84,6 @@ class Pantry():
 
         # Check if file system is read-only. If so, raise error.
         try:
-            # FIXME: this is wasteful -- nothing is ever really deleted in s3
             self.file_system.touch(os.path.join(self.pantry_path,
                                                 "test_read_only.txt"))
             self.file_system.rm(os.path.join(self.pantry_path,

--- a/weave/tests/test_pytest.py
+++ b/weave/tests/test_pytest.py
@@ -73,7 +73,7 @@ def test_github_cicd_sql_server():
         host= os.environ["WEAVE_SQL_HOST"],
         user= os.environ["WEAVE_SQL_USERNAME"],
         password= os.environ["WEAVE_SQL_PASSWORD"],
-        port= os.environ.get("WEAVE_SQL_PORT", 5432),
+        port=int(os.environ.get("WEAVE_SQL_PORT", 5432)),
         )
     cur = conn.cursor()
 


### PR DESCRIPTION
Environment variables are always strings -- even if they are numeric. They need to be cast to the appropriate type before being treated like numbers