### PR TITLE
PRISM-144 (Update MongoLoader.remove_document() to remove all records containing the given uuid, and not just the first)

### DIFF
--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -27,7 +27,7 @@ from .pantry import Pantry
 from .pantry_factory import create_pantry
 from .mongo_loader import MongoLoader
 
-__version__ = "1.12.4"
+__version__ = "1.12.5"
 
 __all__ = [
     "Basket",

--- a/weave/mongo_loader.py
+++ b/weave/mongo_loader.py
@@ -282,4 +282,4 @@ class MongoLoader():
                                 "must be a string")
 
         for collection in collection_names:
-            self.database[collection].delete_one({'uuid':uuid})
+            self.database[collection].delete_many({'uuid':uuid})

--- a/weave/mongo_loader.py
+++ b/weave/mongo_loader.py
@@ -251,12 +251,12 @@ class MongoLoader():
             )
 
     def remove_document(self, uuid, **kwargs):
-        """Delete a document using the uuid in the collections.
+        """Delete all documents containing the given uuid from all collections.
 
         Parameters
         ----------
         uuid: str
-            "uuid" will be used to locate and remove the document from MongoDB
+            "uuid" will be used to locate and remove the documents from MongoDB
             in the supplement, manifest, and metadata collections.
         **metadata_collection: str (default=self.metadata_collection)
             Metadata will be added to the Mongo collection specified.

--- a/weave/tests/test_mongo_db.py
+++ b/weave/tests/test_mongo_db.py
@@ -482,7 +482,7 @@ def test_clear_mongo_works(set_up):
     _SKIP_PYMONGO, reason="Pymongo required for this test"
 )
 def test_mongo_loader_remove_document_works(set_up):
-    """Test duplicate manifest won't be uploaded to mongoDB, based on the UUID.
+    """Test remove document removes all documents containing the given uuid.
     """
     test_uuid = "1234"
 


### PR DESCRIPTION
Fixes a potential issue where multiple records with the same uuid are not deleted if MongoLoader.remove_document(uuid) is called (previously only the first found record would be deleted, potentially leaving untracked/outdated records).