### PR TITLE
Unlock botocore and update runner minio version

### DIFF
--- a/.github/workflows/pytest_and_ruff.yml
+++ b/.github/workflows/pytest_and_ruff.yml
@@ -36,7 +36,7 @@ jobs:
         python-version: "3.10"
     - name: Install minio
       run: |
-        wget https://dl.min.io/server/minio/release/linux-amd64/archive/minio_20230518000536.0.0_amd64.deb -O minio.deb
+        wget https://dl.min.io/server/minio/release/linux-amd64/archive/minio_20250408154124.0.0_amd64.deb -O minio.deb
         sudo dpkg -i minio.deb
     - name: Launch minio
       continue-on-error: true

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Operating System :: OS Independent",
     ],
-    install_requires=["pandas", "s3fs==2024.12.0", "fsspec==2024.12.0",
-                      "jsonschema",
-                      "botocore<=1.35.93", "aiobotocore<=2.17.0"],
+    install_requires=["pandas", "s3fs", "fsspec", "jsonschema"],
     extras_require={
         "extras": ["pymongo", "psycopg2-binary", "sqlalchemy"],
     },

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -27,7 +27,7 @@ from .pantry import Pantry
 from .pantry_factory import create_pantry
 from .mongo_loader import MongoLoader
 
-__version__ = "1.13.1"
+__version__ = "1.13.2"
 
 __all__ = [
     "Basket",


### PR DESCRIPTION
Previously AWS S3 updated how they handle checksums which changed the botocore dependency which broke on unsupported minio versions. As a temporary remedy, we pinned the versions of botocore. This MR remove those pins and uses an updated minio version in the runner. 

Note: Older versions of Minio (Older than the beginning of 2025) will likely not work with the newer botocore versions. Either manually revert your botocore dependencies, or use a newer minio version.