### PR TITLE
Added Basket.download() functionality

### DIFF
--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -27,7 +27,7 @@ from .pantry import Pantry
 from .pantry_factory import create_pantry
 from .mongo_loader import MongoLoader
 
-__version__ = "1.13.5"
+__version__ = "1.14.0"
 
 __all__ = [
     "Basket",

--- a/weave/basket.py
+++ b/weave/basket.py
@@ -314,8 +314,8 @@ class Basket(BasketInitializer):
         destination_path = os.fspath(destination_path)
         if os.path.exists(os.path.join(destination_path, self.uuid)):
             raise FileExistsError(
-                f"Destination path {os.path.join(destination_path, self.uuid)} "
-                "already exists. Please choose a different destination path."
+                f"Destination path {os.path.join(destination_path, self.uuid)}"
+                " already exists. Please choose a different destination path."
             )
 
         if include_artifacts:

--- a/weave/basket.py
+++ b/weave/basket.py
@@ -319,12 +319,11 @@ class Basket(BasketInitializer):
             )
 
         if include_artifacts:
-            # If including artifacts, we can download the entire basket dir.
+            # If including artifacts, download the entire basket dir.
             self.file_system.get(self.basket_path, destination_path,
                                  recursive=True)
         else:
-            # If not including artifacts, we need to loop through only the files
-            # we want to download.
+            # If excluding artifacts, loop through basket ls results.
             destination_path = os.path.join(destination_path, self.uuid)
             os.makedirs(destination_path)
             for file in self.ls():

--- a/weave/tests/test_basket.py
+++ b/weave/tests/test_basket.py
@@ -762,7 +762,7 @@ def test_basket_download_include_artifacts_arg(test_pantry):
         ]
 
         # Check that the basket directory and its contents are present.
-        assert (len(downloaded_paths) == 7)
+        assert len(downloaded_paths) == 7
         assert (
             os.path.join(tmp_download_dir, basket.uuid,
                          tmp_basket_dir_name) in downloaded_paths
@@ -804,7 +804,7 @@ def test_basket_download_include_artifacts_arg(test_pantry):
 
         # Check that the basket directory and its contents (excluding weave
         # artifacts) are present.
-        assert (len(downloaded_paths) == 4)
+        assert len(downloaded_paths) == 4
         assert (
             os.path.join(tmp_download_dir, basket.uuid,
                          tmp_basket_dir_name) in downloaded_paths

--- a/weave/tests/test_basket.py
+++ b/weave/tests/test_basket.py
@@ -705,6 +705,127 @@ def test_read_only_get_data():
         del my_basket
 
 
+def test_basket_download_file_exists_error(test_pantry):
+    """Test that an error is raised when trying to download a basket to a local
+    dir that already has the basket downloaded.
+    """
+    # Create a temporary basket with a test file, and upload it.
+    tmp_basket_dir_name = "test_basket_tmp_dir"
+    tmp_basket_dir = test_pantry.set_up_basket(tmp_basket_dir_name)
+    basket_path = test_pantry.upload_basket(tmp_basket_dir=tmp_basket_dir)
+
+    basket = Basket(basket_path, file_system=test_pantry.file_system)
+    # Create a temporary directory to download the basket to
+    with tempfile.TemporaryDirectory() as tmp_download_dir:
+        # Download the basket to the temporary directory
+        basket.download(tmp_download_dir)
+
+        # Attempt to download the basket again to the same directory
+        with pytest.raises(
+            FileExistsError,
+            match=re.escape(
+                "Destination path "
+                f"{os.path.join(tmp_download_dir, basket.uuid)} "
+                "already exists. Please choose a different destination path."
+            ),
+        ):
+            basket.download(tmp_download_dir)
+
+    # Clean up the temporary directory
+    shutil.rmtree(tmp_download_dir, ignore_errors=True)
+
+
+def test_basket_download_include_artifacts_arg(test_pantry):
+    """Test that the basket download includes or excludes artifacts"""
+    # Create a temporary basket with a the following structure:
+    # test_basket_tmp_dir/
+    # ├── nested_dir/
+    # │   └── another_test.txt
+    # └── test.txt
+    tmp_basket_dir_name = "test_basket_tmp_dir"
+    tmp_basket_dir = test_pantry.set_up_basket(tmp_basket_dir_name)
+    tmp_basket_dir = test_pantry.add_lower_dir_to_temp_basket(tmp_basket_dir)
+    basket_path = test_pantry.upload_basket(
+        tmp_basket_dir=tmp_basket_dir,
+        metadata={"test": "data"},
+    )
+
+    basket = Basket(basket_path, file_system=test_pantry.file_system)
+
+    # Create a temporary directory to download the basket to
+    with tempfile.TemporaryDirectory() as tmp_download_dir:
+        # Download the basket to the temporary directory
+        basket.download(tmp_download_dir, include_artifacts=True)
+        downloaded_paths = [
+            str(f) for f
+            in Path(os.path.join(tmp_download_dir, basket.uuid)).rglob("*")
+        ]
+
+        # Check that the basket directory and its contents are present.
+        assert (len(downloaded_paths) == 7)
+        assert (
+            os.path.join(tmp_download_dir, basket.uuid,
+                         tmp_basket_dir_name) in downloaded_paths
+        )
+        assert (
+            os.path.join(tmp_download_dir, basket.uuid,
+                         tmp_basket_dir_name, "test.txt") in downloaded_paths
+        )
+        assert (
+            os.path.join(tmp_download_dir, basket.uuid, tmp_basket_dir_name,
+                         "nested_dir") in downloaded_paths
+        )
+        assert (
+            os.path.join(tmp_download_dir, basket.uuid, tmp_basket_dir_name,
+                         "nested_dir", "another_test.txt") in downloaded_paths
+        )
+        assert (
+            os.path.join(tmp_download_dir, basket.uuid,
+                         "basket_supplement.json") in downloaded_paths
+        )
+        assert (
+            os.path.join(tmp_download_dir, basket.uuid,
+                         "basket_manifest.json") in downloaded_paths
+        )
+        assert (
+            os.path.join(tmp_download_dir, basket.uuid,
+                         "basket_metadata.json") in downloaded_paths
+        )
+
+        # Clear the downloaded directory
+        shutil.rmtree(os.path.join(tmp_download_dir, basket.uuid))
+
+        # Download the basket again without artifacts
+        basket.download(tmp_download_dir, include_artifacts=False)
+        downloaded_paths = [
+            str(f) for f
+            in Path(os.path.join(tmp_download_dir, basket.uuid)).rglob("*")
+        ]
+
+        # Check that the basket directory and its contents (excluding weave
+        # artifacts) are present.
+        assert (len(downloaded_paths) == 4)
+        assert (
+            os.path.join(tmp_download_dir, basket.uuid,
+                         tmp_basket_dir_name) in downloaded_paths
+        )
+        assert (
+            os.path.join(tmp_download_dir, basket.uuid,
+                         tmp_basket_dir_name, "test.txt") in downloaded_paths
+        )
+        assert (
+            os.path.join(tmp_download_dir, basket.uuid, tmp_basket_dir_name,
+                         "nested_dir") in downloaded_paths
+        )
+        assert (
+            os.path.join(tmp_download_dir, basket.uuid, tmp_basket_dir_name,
+                         "nested_dir", "another_test.txt") in downloaded_paths
+        )
+
+    # Clean up the temporary directory
+    shutil.rmtree(tmp_download_dir, ignore_errors=True)
+
+
 def test_create_basket_in_place(test_pantry):
     """Test create basekt in place works without a pantry.
     """


### PR DESCRIPTION
Added a Basket.download() function that provides users the option to include or exclude weave artifacts (supplement, manifest, and metadata json files) from the download.

By default weave artifacts are excluded, as users intending to download a Basket's contents likely only want the original files uploaded to weave. Additionally, weave artifacts for a given basket can easily be queried and accessed through weave, while the original files were previously more cumbersome to retrieve.

Downloaded baskets are saved to the provided destination directory (or the current working directory by default) in a directory using the basket's UUID. For example, if the provided destination directory is /home/user/ the basket would be saved at /home/user/\<basket-uuid\>/