### PR TITLE
Fix absolute pantry paths

### DIFF
--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -27,7 +27,7 @@ from .pantry import Pantry
 from .pantry_factory import create_pantry
 from .mongo_loader import MongoLoader
 
-__version__ = "1.14.0"
+__version__ = "1.14.1"
 
 __all__ = [
     "Basket",

--- a/weave/basket.py
+++ b/weave/basket.py
@@ -319,12 +319,11 @@ class Basket(BasketInitializer):
             )
 
         if include_artifacts:
-            # If including artifacts, we can download the entire basket dir.
+            # If including artifacts, download the entire basket dir.
             self.file_system.get(self.basket_path, destination_path,
                                  recursive=True)
         else:
-            # If not including artifacts, we need to loop through only the files
-            # we want to download.
+            # If excluding artifacts, loop through basket ls results.
             destination_path = os.path.join(destination_path, self.uuid)
             os.makedirs(destination_path)
             for file in self.ls():

--- a/weave/index/create_index.py
+++ b/weave/index/create_index.py
@@ -56,22 +56,27 @@ def create_index_from_fs(root_dir, file_system):
             basket_dict["upload_time"] = pd.Timestamp(
                                                 basket_dict["upload_time"]
                                          )
-            if basket_dict["basket_type"] != "index":
-                for field in basket_dict.keys():
-                    index_dict[field].append(basket_dict[field])
+            if basket_dict["basket_type"] == "index":
+                continue
 
-                index_dict["address"].append(
-                    os.path.relpath(os.path.dirname(basket_json_address))
-                )
-                index_dict["storage_type"].append(
-                    file_system.__class__.__name__
-                )
+            for field in basket_dict.keys():
+                index_dict[field].append(basket_dict[field])
 
-                if "weave_version" not in basket_dict.keys():
-                    # Every basket uploaded before 0.13.0, should not have a
-                    # version number, therefore every basket with no version
-                    # number will be shown as <0.13.0
-                    index_dict["weave_version"].append("<0.13.0")
+            if basket_json_address.startswith('/'):
+                address = os.path.normpath(os.path.dirname(basket_json_address))
+            else:
+                address = os.path.relpath(os.path.dirname(basket_json_address))
+            index_dict["address"].append(address)
+
+            index_dict["storage_type"].append(
+                file_system.__class__.__name__
+            )
+
+            if "weave_version" not in basket_dict.keys():
+                # Every basket uploaded before 0.13.0, should not have a
+                # version number, therefore every basket with no version
+                # number will be shown as <0.13.0
+                index_dict["weave_version"].append("<0.13.0")
 
     if len(bad_baskets) != 0:
         warnings.warn("baskets found in the following locations "

--- a/weave/index/create_index.py
+++ b/weave/index/create_index.py
@@ -39,7 +39,7 @@ def create_index_from_fs(root_dir, file_system):
     if not file_system.exists(root_dir):
         raise FileNotFoundError(f"'root_dir' does not exist '{root_dir}'")
 
-    basket_jsons = _get_list_of_basket_jsons(root_dir, file_system)
+    manifest_paths = _get_list_of_basket_jsons(root_dir, file_system)
     index_columns = get_index_column_names()
     index_dict = {}
 
@@ -47,11 +47,11 @@ def create_index_from_fs(root_dir, file_system):
         index_dict[key] = []
 
     bad_baskets = []
-    for basket_json_address in basket_jsons:
-        with file_system.open(basket_json_address, "rb") as file:
+    for manifest_path in manifest_paths:
+        with file_system.open(manifest_path, "rb") as file:
             basket_dict = json.load(file)
             if not validate_basket_dict(basket_dict):
-                bad_baskets.append(os.path.dirname(basket_json_address))
+                bad_baskets.append(os.path.dirname(manifest_path))
                 continue
             basket_dict["upload_time"] = pd.Timestamp(
                                                 basket_dict["upload_time"]
@@ -62,10 +62,10 @@ def create_index_from_fs(root_dir, file_system):
             for field in basket_dict.keys():
                 index_dict[field].append(basket_dict[field])
 
-            if basket_json_address.startswith('/'):
-                address = os.path.normpath(os.path.dirname(basket_json_address))
+            if manifest_path.startswith('/'):
+                address = os.path.normpath(os.path.dirname(manifest_path))
             else:
-                address = os.path.relpath(os.path.dirname(basket_json_address))
+                address = os.path.relpath(os.path.dirname(manifest_path))
             index_dict["address"].append(address)
 
             index_dict["storage_type"].append(

--- a/weave/index/index_sql.py
+++ b/weave/index/index_sql.py
@@ -266,16 +266,11 @@ class IndexSQL(IndexABC):
             raise FileNotFoundError("'pantry_path' does not exist: "
                                     f"'{self.pantry_path}'")
 
-        basket_jsons = [x for x in self.file_system.find(self.pantry_path)
-            if x.endswith("basket_manifest.json")
-        ]
-
-        for basket_json_address in basket_jsons:
-            entry = create_index_from_fs(basket_json_address,
-                                         file_system=self.file_system)
-            if not entry.empty:
-                if len(self.get_rows(entry['uuid'].iloc[0])) == 0:
-                    self.track_basket(entry)
+        # Batch generate the index from the file system.
+        # pylint: disable-next=fixme
+        # TODO: Split into multiple batches if the pantry is large.
+        index_df = create_index_from_fs(self.pantry_path, self.file_system)
+        self.track_basket(index_df)
 
     def clear_index(self, refresh=False, **kwargs):
         """Deletes/clears the previously populated index.

--- a/weave/index/list_baskets.py
+++ b/weave/index/list_baskets.py
@@ -8,15 +8,15 @@ def _get_list_of_basket_jsons(root_dir, file_system):
     Parameters:
     -----------
     root_dir: str
-        Path to search for basket manifests (doesn't have to be the pantry root)
+        Path to search for basket manifests--doesn't have to be the pantry root
     file_system: fsspec object
         The file system to search in.
 
     Returns:
     ----------
-    A list of paths to basket_manifest.json files found under the given root_dir.
+    A list of paths to basket_manifest.json files found under the given dir
     """
-    # In some instances, root_dir may be the empty str and should be left as is.
+    # In some instances, root_dir may be the empty str and should be left as is
     root_dir = os.path.normpath(root_dir) if root_dir != '' else ''
     manifest_paths = []
     for path in file_system.find(root_dir):

--- a/weave/index/list_baskets.py
+++ b/weave/index/list_baskets.py
@@ -1,5 +1,28 @@
 """Wherein functionality concerning listing basket jsons is contained."""
+import os
+
 
 def _get_list_of_basket_jsons(root_dir, file_system):
-    return [x for x in file_system.find(root_dir)
-            if x.endswith("basket_manifest.json")]
+    """Return a list of basket manifest paths in the given root dir.
+
+    Parameters:
+    -----------
+    root_dir: str
+        Path to search for basket manifests (doesn't have to be the pantry root)
+    file_system: fsspec object
+        The file system to search in.
+
+    Returns:
+    ----------
+    A list of paths to basket_manifest.json files found under the given root_dir.
+    """
+    # In some instances, root_dir may be the empty str and should be left as is.
+    root_dir = os.path.normpath(root_dir) if root_dir != '' else ''
+    manifest_paths = []
+    for path in file_system.find(root_dir):
+        if path.endswith("basket_manifest.json"):
+            # The find method returns absolute paths which need to be trimmed
+            # to start from the root_dir instead of the full path.
+            # This is done to ensure returned paths are relative to the pantry.
+            manifest_paths.append(path[path.index(root_dir):])
+    return manifest_paths

--- a/weave/index/list_baskets.py
+++ b/weave/index/list_baskets.py
@@ -18,6 +18,8 @@ def _get_list_of_basket_jsons(root_dir, file_system):
     """
     # In some instances, root_dir may be the empty str and should be left as is
     root_dir = os.path.normpath(root_dir) if root_dir != '' else ''
+    # On Windows find() returns with forward slashes, the root dir must match.
+    root_dir = root_dir.replace(os.sep, '/')
     manifest_paths = []
     for path in file_system.find(root_dir):
         if path.endswith("basket_manifest.json"):

--- a/weave/mongo_loader.py
+++ b/weave/mongo_loader.py
@@ -67,6 +67,12 @@ class MongoLoader():
         # pantry_path if it is not present.)
         self.database_name = self.mongo_config.get(
             "mongodb_database", self.pantry.pantry_path)
+        for invalid_char in [" ", ".", "$", "/", "\\", "\x00", '"']:
+            if invalid_char in self.database_name:
+                self.database_name = self.database_name.replace(
+                    invalid_char,
+                    "",
+                )
         self.database = self.mongo_client[self.database_name]
 
         self.metadata_collection = self.mongo_config.get(


### PR DESCRIPTION
Previously, if a pantry_path was an absolute path (ie, on linux LocalFileSystem if it started with a '/') many errors would occur.
The primary problem was the basket-address stored in the index would resolve the absolute address as a relative path. This incorrect resolution would error out during basket validation and raise the "Attempting to access basket outside of pantry" ValueError. 

This PR addresses the basket-address resolution bugs, and creates a test to ensure absolute pantry paths function as expected.