### PR TITLE
modified test to function based off of python version

### DIFF
--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -28,7 +28,7 @@ from .pantry_factory import create_pantry
 from .mongo_loader import MongoLoader
 
 
-__version__ = "1.14.1"
+__version__ = "1.14.2"
 
 
 __all__ = [

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -28,7 +28,7 @@ from .pantry_factory import create_pantry
 from .mongo_loader import MongoLoader
 
 
-__version__ = "1.14.0"
+__version__ = "1.14.1"
 
 
 __all__ = [

--- a/weave/tests/test_validate.py
+++ b/weave/tests/test_validate.py
@@ -537,7 +537,7 @@ def test_validate_invalid_manifest_json(test_validate):
     ) as err:
         validate.validate_pantry(pantry)
 
-    if (version_info[1] >= 13):
+    if version_info[1] >= 13:
         assert str(err.value) == ("Pantry could not be loaded into index: "
                               "Illegal trailing comma before end of "
                               "object: line 1 column 9 (char 8)")

--- a/weave/tests/test_validate.py
+++ b/weave/tests/test_validate.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from sys import version_info
 from pathlib import Path
 
 import pytest
@@ -536,9 +537,14 @@ def test_validate_invalid_manifest_json(test_validate):
     ) as err:
         validate.validate_pantry(pantry)
 
-    assert str(err.value) == ("Pantry could not be loaded into index: "
+    if (version_info[1] >= 13):
+        assert str(err.value) == ("Pantry could not be loaded into index: "
                               "Illegal trailing comma before end of "
                               "object: line 1 column 9 (char 8)")
+    else:
+        assert str(err.value) == ("Pantry could not be loaded into index: "
+                              "Expecting property name enclosed in double"
+                              " quotes: line 1 column 10 (char 9)")
 
 
 def test_validate_invalid_supplement_schema(test_validate):


### PR DESCRIPTION
This change allows the modified test to pass without being dependent on the python version (works from 3.10-3.13). Otherwise, in the version change from 3.12 to 3.13, there is a modification in the way JSON is parsed, which changes the error returned, failing the test.