### PR TITLE
Fix Basket.ls kwargs

### DIFF
--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -28,7 +28,7 @@ from .pantry_factory import create_pantry
 from .mongo_loader import MongoLoader
 
 
-__version__ = "1.14.2"
+__version__ = "1.14.3"
 
 __all__ = [
     "Basket",


### PR DESCRIPTION
Fixes two issues with the Basket.ls function.
- The refresh=True argument is primarily used on S3FS implementations, and may not be used and/or may raise an error in different FSSPEC implementations. This PR addresses that issue by optionally adding it only if the used file system is an S3FS.
- Most FSSPEC implementations default ls(detail=False) though some may not. Since the Basket ls function assumes the file_system ls call will return a list (ie detail=False), it is now explicitly set to False.