### PR TITLE
Update Postgres schema invalid char sanitation 

### DIFF
--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -28,7 +28,7 @@ from .pantry_factory import create_pantry
 from .mongo_loader import MongoLoader
 
 
-__version__ = "1.14.3"
+__version__ = "1.14.4"
 
 __all__ = [
     "Basket",

--- a/weave/index/index_sql.py
+++ b/weave/index/index_sql.py
@@ -79,8 +79,15 @@ class IndexSQL(IndexABC):
 
         # Set the schema name (defaults to pantry_path). If the schema does not
         # exist, it will be created.
-        d_schema_name = self._pantry_path.replace(os.sep, "_")\
-            .replace("-", "_")
+        d_schema_name = self._pantry_path
+        # Postgres allows A-Za-z0-9_, while this list is not exhaustive, it
+        # will cover most commonly found invalid chars that could be in a path.
+        # In the future in may be worth looking into using quote_ident to
+        # safely quote *any* schema name. (This would potentially break
+        # existing schemas, so it is not done here.)
+        for invalid_char in [" ", ".", "$", "/", "\\", "\x00", '"', "-"]:
+            d_schema_name = d_schema_name.replace(invalid_char, "_")
+
         if d_schema_name == "":
             d_schema_name = "weave"
         self._pantry_schema = kwargs.get("pantry_schema", d_schema_name)


### PR DESCRIPTION
The schema name sanitation was previously based on replacing the os path separator from the pantry path, however, this left cases where a pantry path could use a separator that is not native to the weave client os (ie, the pantry path is on a linux based file system with '/' separators, but the user is using weave on windows.)
This PR makes the invalid char sanitation a little more robust...
This is not an exhaustive fix for invalid schema names. In the future it may be worth looking into using pscopg2.extensions.quote_ident() to create the schema names (this may allow full pantry paths with their original path separators instead of replacement with '_'). Using quote_ident would likely break existing schemas if the pantry path includes path separators.