### PR TITLE
Added metadata update feature

### DIFF
--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -28,7 +28,7 @@ from .pantry_factory import create_pantry
 from .mongo_loader import MongoLoader
 
 
-__version__ = "1.14.3"
+__version__ = "1.14.4"
 
 __all__ = [
     "Basket",

--- a/weave/index/index_sql.py
+++ b/weave/index/index_sql.py
@@ -79,8 +79,15 @@ class IndexSQL(IndexABC):
 
         # Set the schema name (defaults to pantry_path). If the schema does not
         # exist, it will be created.
-        d_schema_name = self._pantry_path.replace(os.sep, "_")\
-            .replace("-", "_")
+        d_schema_name = self._pantry_path
+        # Postgres allows A-Za-z0-9_, while this list is not exhaustive, it
+        # will cover most commonly found invalid chars that could be in a path.
+        # In the future in may be worth looking into using quote_ident to
+        # safely quote *any* schema name. (This would potentially break
+        # existing schemas, so it is not done here.)
+        for invalid_char in [" ", ".", "$", "/", "\\", "\x00", '"', "-"]:
+            d_schema_name = d_schema_name.replace(invalid_char, "_")
+
         if d_schema_name == "":
             d_schema_name = "weave"
         self._pantry_schema = kwargs.get("pantry_schema", d_schema_name)

--- a/weave/mongo_loader.py
+++ b/weave/mongo_loader.py
@@ -100,6 +100,17 @@ class MongoLoader():
             Metadata will be added to the Mongo collection specified. If not
             provided, populate using self.metadata_collection (which defaults
             to "metadata" if otherwise unspecified).
+        **replace: bool (optional; defaults to False)
+            If True, the metadata for the given uuids will be replaced in the
+            MongoDB collection. If False, the metadata will only be added if
+            it does not already exist in the MongoDB collection.
+        **metadata_dict: dict (optional)
+            A dictionary containing metadata for a single basket uuid to be
+            added to the MongoDB. This offers a way to add metadata that
+            perserves the original types of the metadata fields
+            (e.g. datetime, int, float, etc.). If provided, only one uuid
+            is allowed in the uuids list. If not provided, the metadata will be
+            retrieved from the basket's metadata.json file.
         """
         collection = kwargs.get("collection", self.metadata_collection)
         if not isinstance(uuids, list):
@@ -111,22 +122,32 @@ class MongoLoader():
             raise TypeError("Invalid datatype for metadata collection: "
                             "must be a string")
 
+        metadata_dict = kwargs.get("metadata_dict", None)
+        if metadata_dict and len(uuids) != 1:
+            raise ValueError("If metadata_dict is provided only one uuid is "
+            "allowed.")
+
         for uuid in uuids:
             basket = Basket(uuid, pantry=self.pantry)
-            metadata = basket.get_metadata()
+            if metadata_dict:
+                metadata = metadata_dict
+            else:
+                metadata = basket.get_metadata()
             if not metadata:
                 continue
             mongo_metadata = {}
             mongo_metadata["uuid"] = basket.uuid
             mongo_metadata["basket_type"] = basket.basket_type
-            mongo_metadata.update(metadata)
+            mongo_metadata["parent_uuids"] = basket.parent_uuids
+            mongo_metadata.update(metadata) # Prioritize the metadata provided
 
-            # If the UUID already has metadata loaded in MongoDB,
-            # the metadata should not be loaded to MongoDB again.
-            if 0 == self.database[
-                self.metadata_collection
-            ].count_documents({"uuid": basket.uuid}):
-                self.database[collection].insert_one(mongo_metadata)
+            # If the UUID already has metadata loaded in MongoDB, the metadata
+            # should not be loaded to MongoDB again unless replace is True.
+            if (kwargs.get("replace") or
+                0 == self.database[self.metadata_collection]\
+                    .count_documents({"uuid": basket.uuid})
+            ):
+                self.database[collection].replace_one({"uuid": basket.uuid}, mongo_metadata, upsert=True)
 
     def load_mongo_manifest(self, uuids, **kwargs):
         """Load manifest from baskets into the mongo database.
@@ -234,7 +255,9 @@ class MongoLoader():
         supplement_collection = kwargs.get("supplement_collection",
                                            self.supplement_collection)
 
-        self.load_mongo_metadata(uuids, collection=metadata_collection)
+        self.load_mongo_metadata(uuids,
+                                 collection=metadata_collection,
+                                 **kwargs)
         self.load_mongo_manifest(uuids, collection=manifest_collection)
         self.load_mongo_supplement(uuids, collection=supplement_collection)
 

--- a/weave/pantry.py
+++ b/weave/pantry.py
@@ -277,8 +277,10 @@ class Pantry():
         self.index.track_basket(single_indice_index)
 
         if self.mongo_client is not None:
-            MongoLoader(self).\
-                load_mongo(single_indice_index.iloc[0].uuid)
+            MongoLoader(self).load_mongo(
+                single_indice_index.iloc[0].uuid,
+                metadata_dict=metadata,
+            )
 
         return single_indice_index
 

--- a/weave/tests/test_basket.py
+++ b/weave/tests/test_basket.py
@@ -291,6 +291,68 @@ def test_basket_get_metadata(test_pantry):
     assert metadata_in == metadata
 
 
+def test_basket_update_metadata(test_pantry):
+    """Test that the update_metadata function updates the metadata keys and
+    file"""
+    metadata_in = {"test": 1}
+
+    # Create a temporary basket with a test file, and upload it.
+    tmp_basket_dir_name = "test_basket_tmp_dir"
+    tmp_basket_dir = test_pantry.set_up_basket(tmp_basket_dir_name)
+    basket_path = test_pantry.upload_basket(
+        tmp_basket_dir, metadata=metadata_in
+    )
+
+    basket = Basket(Path(basket_path), file_system=test_pantry.file_system)
+
+    # Check get_metadata returns the same values used during the upload.
+    metadata = basket.get_metadata()
+    assert metadata_in == metadata
+
+    # Update the metadata with new values.
+    metadata_update = {"test": 2, "new": "value"}
+    basket.update_metadata(metadata_update)
+    metadata = basket.get_metadata()
+    assert metadata == {"test": 2, "new": "value"}
+
+    # Check that the metadata file was updated in the file system.
+    if basket.file_system.exists(basket.metadata_path):
+        with basket.file_system.open(basket.metadata_path, "rb") as file:
+            metadata = json.load(file)
+            assert metadata == {"test": 2, "new": "value"}
+
+
+def test_basket_replace_metadata(test_pantry):
+    """Test that the replace_metadata function replaces the metadata keys and
+    file (dropping old keys that are not in the new metadata)."""
+    metadata_in = {"test": 1}
+
+    # Create a temporary basket with a test file, and upload it.
+    tmp_basket_dir_name = "test_basket_tmp_dir"
+    tmp_basket_dir = test_pantry.set_up_basket(tmp_basket_dir_name)
+    basket_path = test_pantry.upload_basket(
+        tmp_basket_dir, metadata=metadata_in
+    )
+
+    basket = Basket(Path(basket_path), file_system=test_pantry.file_system)
+
+    # Check get_metadata returns the same values used during the upload.
+    metadata = basket.get_metadata()
+    assert metadata_in == metadata
+
+    # Replace the metadata with new values (replaces the test key with testing)
+    metadata_update = {"testing": 2, "new": "value"}
+    basket.replace_metadata(metadata_update)
+    metadata = basket.get_metadata()
+    assert metadata == {"testing": 2, "new": "value"}
+
+    # Check that the metadata file was updated in the file system.
+    if basket.file_system.exists(basket.metadata_path):
+        with basket.file_system.open(basket.metadata_path, "rb") as file:
+            metadata = json.load(file)
+            assert metadata == {"testing": 2, "new": "value"}
+
+
 def test_basket_get_metadata_cached(test_pantry):
     """Test that the get_metadata function retrieves cached copies of a
     basket's metadata.

--- a/weave/tests/test_mongo_db.py
+++ b/weave/tests/test_mongo_db.py
@@ -91,8 +91,10 @@ def test_load_mongo_metadata(set_up):
     )
 
     truth_db = [
-        {"uuid": "1234", "basket_type": "test_basket", "key1": "value1"},
-        {"uuid": "4321", "basket_type": "test_basket", "key2": "value2"},
+        {"uuid": "1234", "basket_type": "test_basket",
+         "key1": "value1", "parent_uuids": []},
+        {"uuid": "4321", "basket_type": "test_basket",
+         "key2": "value2", "parent_uuids": []},
     ]
 
     db_data = list(set_up.database[set_up.metadata_collection].find({}))
@@ -181,8 +183,10 @@ def test_load_mongo(set_up):
     )
 
     metadata_truth_db = [
-        {"uuid": "1234", "basket_type": "test_basket", "key1": "value1"},
-        {"uuid": "4321", "basket_type": "test_basket", "key2": "value2"},
+        {"uuid": "1234", "basket_type": "test_basket",
+         "key1": "value1", "parent_uuids": []},
+        {"uuid": "4321", "basket_type": "test_basket",
+         "key2": "value2", "parent_uuids": []},
     ]
     metadata = list(set_up.database[set_up.metadata_collection].find({}))
     compared_metadata = []
@@ -261,6 +265,161 @@ def test_load_mongo_metadata_check_for_duplicate_uuid(set_up):
         {"uuid": test_uuid}
     )
     assert count == 1, "duplicate uuid inserted"
+
+
+@pytest.mark.skipif(
+    get_pymongo_skip_condition(), reason=get_pymongo_skip_reason()
+)
+def test_load_mongo_metadata_replace_works_with_metadata_dict(set_up):
+    """Test replace metadata updates the right record and doesn't create a new
+    one.
+    """
+    test_uuid = "1234"
+
+    mongo_loader = MongoLoader(pantry=set_up.pantry)
+    mongo_loader.load_mongo_metadata(
+        [test_uuid],
+        collection=set_up.metadata_collection,
+    )
+    mongo_loader.load_mongo_metadata(
+        [test_uuid],
+        replace=True,
+        metadata_dict={"key3": "new_value"},
+        collection=set_up.metadata_collection,
+    )
+
+    count = set_up.database[set_up.metadata_collection].count_documents(
+        {"uuid": test_uuid}
+    )
+    assert count == 1, "duplicate uuid inserted"
+    metadata = set_up.database[set_up.metadata_collection].find_one(
+        {"uuid": test_uuid}
+    )
+    # Expected mongo returns: _id, uuid, basket_type, parent_uuids, key3
+    assert len(metadata) == 5, "expected 5 metadata keys after replace"
+    assert metadata["key3"] == "new_value", "metadata not replaced correctly"
+    assert metadata["basket_type"] == "test_basket", \
+        "basket_type not set correctly after replace"
+    assert metadata["parent_uuids"] == [], \
+        "parent_uuids not set correctly after replace"
+    assert metadata["uuid"] == test_uuid, \
+        "uuid not set correctly after replace"
+
+
+@pytest.mark.skipif(
+    get_pymongo_skip_condition(), reason=get_pymongo_skip_reason()
+)
+def test_load_mongo_metadata_no_replace_flag_doesnt_update(set_up):
+    """Test that the original metadata is not replaced if replace is not set to
+    True.
+    """
+    test_uuid = "1234"
+
+    mongo_loader = MongoLoader(pantry=set_up.pantry)
+    mongo_loader.load_mongo_metadata(
+        [test_uuid],
+        collection=set_up.metadata_collection,
+    )
+    mongo_loader.load_mongo_metadata(
+        [test_uuid],
+        replace=False, # Should not replace metadata
+        metadata_dict={"key3": "new_value"},
+        collection=set_up.metadata_collection,
+    )
+
+    count = set_up.database[set_up.metadata_collection].count_documents(
+        {"uuid": test_uuid}
+    )
+    assert count == 1, "duplicate uuid inserted"
+    metadata = set_up.database[set_up.metadata_collection].find_one(
+        {"uuid": test_uuid}
+    )
+    # Expected mongo returns: _id, uuid, basket_type, parent_uuids, key1
+    assert len(metadata) == 5, "expected 5 metadata keys"
+    assert metadata["key1"] == "value1", "metadata not replaced correctly"
+    assert "key3" not in metadata, \
+        "metadata should not have been updated without replace=True"
+
+
+@pytest.mark.skipif(
+    get_pymongo_skip_condition(), reason=get_pymongo_skip_reason()
+)
+def test_load_mongo_metadata_metadata_dict_exception(set_up):
+    """Test load mongo metadata raises the right exception when
+    metadata_dict is provided but more than one uuid is given.
+    """
+    test_uuid = "1234"
+
+    mongo_loader = MongoLoader(pantry=set_up.pantry)
+    with pytest.raises(
+        ValueError, match="If metadata_dict is provided only one uuid is "
+        "allowed."
+    ):
+        # Only one uuid allowed with metadata_dict kwarg.
+        mongo_loader.load_mongo_metadata(
+            [test_uuid, "4321"], # Only one uuid allowed with metadata_dict
+            replace=True,
+            metadata_dict={"key3": "new_value"},
+            collection=set_up.metadata_collection,
+        )
+
+
+@pytest.mark.skipif(
+    get_pymongo_skip_condition(), reason=get_pymongo_skip_reason()
+)
+def test_basket_replace_metadata_replaces_mongo_metadata(set_up):
+    """Test that the replace_metadata function replaces the metadata mongo
+    record"""
+    test_uuid = "1234"
+
+    pantry = set_up.pantry
+    basket = pantry.get_basket(test_uuid)
+    og_metadata = basket.get_metadata().copy()
+    new_metadata = {"key3": "new_value", "key4": "new_value2"}
+    basket.replace_metadata(new_metadata)
+
+    # Check that the metadata was updated in mongo collection.
+    mongo_loader = MongoLoader(pantry=pantry)
+    mongo_metadata = mongo_loader.database[mongo_loader.metadata_collection]\
+        .find_one({"uuid": test_uuid})
+
+    assert mongo_metadata is not None, "Metadata should exist in mongo"
+    assert mongo_metadata["uuid"] == test_uuid
+    assert mongo_metadata["basket_type"] == "test_basket"
+    assert mongo_metadata["parent_uuids"] == basket.parent_uuids
+    assert "key1" not in mongo_metadata, \
+        "key1 should not be in metadata after replace_metadata"
+    assert mongo_metadata["key3"] == "new_value"
+    assert mongo_metadata["key4"] == "new_value2"
+
+
+@pytest.mark.skipif(
+    get_pymongo_skip_condition(), reason=get_pymongo_skip_reason()
+)
+def test_basket_update_metadata_updates_mongo_metadata(set_up):
+    """Test that the update_metadata function updates the metadata mongo record
+    """
+    test_uuid = "1234"
+
+    pantry = set_up.pantry
+    basket = pantry.get_basket(test_uuid)
+    og_metadata = basket.get_metadata().copy()
+    new_metadata = {"key3": "new_value", "key4": "new_value2"}
+    basket.update_metadata(new_metadata)
+
+    # Check that the metadata was updated in mongo collection.
+    mongo_loader = MongoLoader(pantry=pantry)
+    mongo_metadata = mongo_loader.database[mongo_loader.metadata_collection]\
+        .find_one({"uuid": test_uuid})
+
+    assert mongo_metadata is not None, "Metadata should exist in mongo"
+    assert mongo_metadata["uuid"] == test_uuid
+    assert mongo_metadata["basket_type"] == "test_basket"
+    assert mongo_metadata["parent_uuids"] == basket.parent_uuids
+    assert mongo_metadata["key1"] == og_metadata["key1"], \
+        "key1 should not be removed from metadata after update_metadata"
+    assert mongo_metadata["key3"] == "new_value"
+    assert mongo_metadata["key4"] == "new_value2"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
This PR adds functionality to allow the update/replacement of a Basket's metadata.
Two functions are added to the Basket class: Basket.update_metadata() and Basket.replace_metadata() (replace_metadata is an alias for update_metadata with the replace kwarg set to True.

If the replace kwarg is set, it will completely overwrite the existing basket's metadata file in the file system. If replace is False (default) it will read the existing metadata, and use the dictionary update function to update and then replace the metadata file. If the new functions are called through a Basket that has a pantry associated with it, the functions will update the mongo metadata collection if the pantry is connected to a Mongo DB.

There is also a change to the MongoLoader load_mongo_metadata function. Previously the mongo metadata collections were populated from the metadata json file, which could result in losing important datatype context (ie datetime objects written to json become strings, and are loaded into the metadata collection as strings instead of datetime objects). The new changes allow a metadata_dict kwarg to be passed directly to the load_mongo_metadata function to preserve original python datatype objects (thus now datetime objects in the upload_basket metadata will be loaded into mongo as datetimes enabling more complex querying capabilities).

