### PR TITLE
Fix concurrent Pantry instantiation bug (read only pantry bug)

### DIFF
--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -27,7 +27,7 @@ from .pantry import Pantry
 from .pantry_factory import create_pantry
 from .mongo_loader import MongoLoader
 
-__version__ = "1.15.4"
+__version__ = "1.15.5"
 
 __all__ = [
     "Basket",

--- a/weave/pantry.py
+++ b/weave/pantry.py
@@ -2,6 +2,7 @@
 """
 import json
 import os
+import uuid
 import warnings
 from pathlib import PurePosixPath, PurePath
 
@@ -95,10 +96,12 @@ class Pantry():
 
         # Check if file system is read-only. If so, raise error.
         try:
-            self.file_system.touch(os.path.join(self.pantry_path,
-                                                "test_read_only.txt"))
-            self.file_system.rm(os.path.join(self.pantry_path,
-                                                "test_read_only.txt"))
+            test_file_path = os.path.join(
+                self.pantry,
+                f"test_read_only_{uuid.uuid4().hex}.txt"
+            )
+            self.file_system.touch(test_file_path)
+            self.file_system.rm(test_file_path)
             self.is_read_only = False
         except (OSError, ValueError):
             self.is_read_only = True

--- a/weave/pantry.py
+++ b/weave/pantry.py
@@ -97,7 +97,7 @@ class Pantry():
         # Check if file system is read-only. If so, raise error.
         try:
             test_file_path = os.path.join(
-                self.pantry,
+                self.pantry_path,
                 f"test_read_only_{uuid.uuid4().hex}.txt"
             )
             self.file_system.touch(test_file_path)


### PR DESCRIPTION
Addresses an issue that occurs when two pantry objects are instantiated at the same time.
Previously the Pantry constructor would attempt to create and then delete a file to test if a file system is read only.
If two pantries tried doing this at the same time, there could be collisions resulting in both erroring out.

This MR copies a fix that was present in the development branch, but was not added to the main branch.
The fix consists of adding a uuid to the test file path to prevent collisions.